### PR TITLE
Fix reduced-reference state conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,13 @@ A structural gap is detected when the C–N distance between consecutive
 residues exceeds 2.66 Å. A gap skips only the affected CDR correction and
 emits a warning; other regions continue normally.
 
+T-cell receptors are not an officially supported SAbR target. For
+experimental low-level use, align a TCR against the K reference because that
+reference includes IMGT position 10, as TCRs do. Pass the actual TCR chain
+type (`A`, `B`, `G`, or `D`) only to the ANARCI conversion step, together with
+`ref_type="K"`. This workaround is limited to IMGT and AHo numbering; the
+other bundled schemes are antibody-specific.
+
 ## Development
 
 ```bash

--- a/docs/index.md
+++ b/docs/index.md
@@ -166,6 +166,16 @@ only for sequence generation. Original residue names and atoms are preserved.
 Unknown or ambiguous polymer chemistry is rejected rather than converted to
 `X`.
 
+## Experimental TCR use
+
+T-cell receptors are not an officially supported SAbR target. Experimental
+users of the low-level alignment and numbering modules should align TCRs
+against the K reference because it includes IMGT position 10, as TCRs do.
+Pass the actual TCR chain type (`A`, `B`, `G`, or `D`) only to the ANARCI
+conversion step, together with `ref_type="K"`. This workaround supports IMGT
+and AHo numbering only; Chothia, Kabat, Martin, and Wolfguy are
+antibody-specific.
+
 ## Errors
 
 Common errors include:

--- a/src/sabr/numbering.py
+++ b/src/sabr/numbering.py
@@ -1,6 +1,9 @@
 """Convert an IMGT alignment into one of ANARCI's numbering schemes."""
 
+import functools
 import logging
+from collections.abc import Mapping
+from importlib.resources import files
 
 import numpy as np
 
@@ -9,54 +12,40 @@ from sabr._anarci import schemes
 
 LOGGER = logging.getLogger(__name__)
 
-MISSING_IMGT_POSITIONS = {
-    "H": frozenset({10, 31, 32, 33, 34, 60, 61, 73}),
-    "K": frozenset(
-        {
-            31,
-            32,
-            33,
-            34,
-            35,
-            58,
-            59,
-            60,
-            61,
-            62,
-            63,
-            64,
-            73,
-            81,
-            82,
-            110,
-            111,
-            112,
-            113,
-            128,
-        }
-    ),
-    "L": frozenset(
-        {
-            10,
-            32,
-            33,
-            34,
-            58,
-            59,
-            60,
-            61,
-            62,
-            63,
-            64,
-            73,
-            81,
-            82,
-            111,
-            112,
-            128,
-        }
-    ),
-}
+
+@functools.cache
+def _load_missing_imgt_positions() -> dict[str, frozenset[int]]:
+    """Derive absent IMGT positions from the canonical reference metadata."""
+    path = files("sabr.assets") / "embeddings_noise_0.0.npz"
+    with (
+        path.open("rb") as handle,
+        np.load(handle, allow_pickle=True) as archive,
+    ):
+        data = archive["arr_0"].item()
+
+    all_positions = frozenset(range(1, constants.IMGT_MAX_POSITION + 1))
+    return {
+        chain_type: all_positions.difference(
+            int(position) for position in data[chain_type]["idxs"]
+        )
+        for chain_type in constants.CHAIN_TYPES
+    }
+
+
+class _MissingIMGTPositions(Mapping[str, frozenset[int]]):
+    """Read-only, lazily loaded missing-position metadata."""
+
+    def __getitem__(self, chain_type: str) -> frozenset[int]:
+        return _load_missing_imgt_positions()[chain_type]
+
+    def __iter__(self):
+        return iter(_load_missing_imgt_positions())
+
+    def __len__(self) -> int:
+        return len(_load_missing_imgt_positions())
+
+
+MISSING_IMGT_POSITIONS = _MissingIMGTPositions()
 _TCR_CHAIN_TYPES = frozenset({"A", "B", "G", "D"})
 
 

--- a/src/sabr/numbering.py
+++ b/src/sabr/numbering.py
@@ -9,11 +9,97 @@ from sabr._anarci import schemes
 
 LOGGER = logging.getLogger(__name__)
 
+MISSING_IMGT_POSITIONS = {
+    "H": frozenset({10, 31, 32, 33, 34, 60, 61, 73}),
+    "K": frozenset(
+        {
+            31,
+            32,
+            33,
+            34,
+            35,
+            58,
+            59,
+            60,
+            61,
+            62,
+            63,
+            64,
+            73,
+            81,
+            82,
+            110,
+            111,
+            112,
+            113,
+            128,
+        }
+    ),
+    "L": frozenset(
+        {
+            10,
+            32,
+            33,
+            34,
+            58,
+            59,
+            60,
+            61,
+            62,
+            63,
+            64,
+            73,
+            81,
+            82,
+            111,
+            112,
+            128,
+        }
+    ),
+}
+_TCR_CHAIN_TYPES = frozenset({"A", "B", "G", "D"})
 
-def alignment_to_states(matrix: np.ndarray) -> tuple:
+
+def _validate_reference_positions(
+    matrix: np.ndarray,
+    ref_positions: tuple[int, ...] | None,
+) -> tuple[int, ...] | None:
+    """Validate and normalize reduced-reference IMGT positions."""
+    if ref_positions is None:
+        return None
+    if not isinstance(ref_positions, tuple):
+        raise ValueError("ref_positions must be a tuple.")
+    if len(ref_positions) != matrix.shape[1]:
+        raise ValueError(
+            "ref_positions length must match the alignment column count."
+        )
+    if not all(
+        isinstance(position, int) and not isinstance(position, bool)
+        for position in ref_positions
+    ):
+        raise ValueError("ref_positions must contain only integers.")
+    if not all(
+        1 <= position <= constants.IMGT_MAX_POSITION
+        for position in ref_positions
+    ):
+        raise ValueError("ref_positions must be between IMGT 1 and 128.")
+    if any(
+        right <= left for left, right in zip(ref_positions, ref_positions[1:])
+    ):
+        raise ValueError("ref_positions must be strictly increasing.")
+    return ref_positions
+
+
+def alignment_to_states(
+    matrix: np.ndarray,
+    *,
+    ref_positions: tuple[int, ...] | None = None,
+) -> tuple:
     """Return ANARCI-compatible states and the first aligned query row."""
     if matrix.ndim != 2:
         raise ValueError("Alignment matrix must be two-dimensional.")
+    if ref_positions is not None:
+        ref_positions = _validate_reference_positions(matrix, ref_positions)
     path = sorted(np.argwhere(matrix.T == 1).tolist())
     if not path:
         raise ValueError("Alignment matrix contains no aligned residues.")
@@ -29,11 +115,19 @@ def alignment_to_states(matrix: np.ndarray) -> tuple:
     orphan_rows = {
         row for row in range(first_row, last_row + 1) if row not in row_columns
     }
-    offset = first_column - first_row
+    first_position = (
+        ref_positions[first_column]
+        if ref_positions is not None
+        else first_column + 1
+    )
+    imgt_start = first_position - 1
+    offset = imgt_start - first_row
     states = []
 
     for column in range(first_column, last_column + 1):
-        imgt_position = column + 1
+        imgt_position = (
+            ref_positions[column] if ref_positions is not None else column + 1
+        )
         if column not in column_rows:
             states.append(((imgt_position, "d"), None))
             continue
@@ -53,10 +147,35 @@ def alignment_to_states(matrix: np.ndarray) -> tuple:
                 if row in orphan_rows:
                     states.append(((imgt_position, "i"), row + offset))
 
-    return states, first_column, first_row
+    return states, imgt_start, first_row
+
+
+def _insert_missing_deletions(states: list, ref_type: str) -> list:
+    """Add absent reference positions as idempotent deletion states."""
+    if ref_type not in MISSING_IMGT_POSITIONS:
+        raise ValueError("ref_type must be 'H', 'K', or 'L'.")
+
+    represented = {state[0][0] for state in states}
+    missing = MISSING_IMGT_POSITIONS[ref_type].difference(represented)
+    if not missing:
+        return states
+
+    completed = [
+        *states,
+        *[((position, "d"), None) for position in sorted(missing)],
+    ]
+    completed.sort(key=lambda state: state[0][0])
+    LOGGER.debug(
+        "Inserted %d deletion states for the %s reference.",
+        len(missing),
+        ref_type,
+    )
+    return completed
 
 
 def _apply_scheme(states: list, sequence: str, scheme: str, chain_type: str):
+    if chain_type in _TCR_CHAIN_TYPES and scheme not in ("imgt", "aho"):
+        raise ValueError("TCR chain types support only IMGT or AHo numbering.")
     if scheme == "imgt":
         return schemes.number_imgt(states, sequence)
     if scheme == "aho":
@@ -91,9 +210,27 @@ def _number_domain_alignment(
     sequence: str,
     scheme: str,
     chain_type: str,
+    *,
+    ref_type: str | None = None,
+    ref_positions: tuple[int, ...] | None = None,
 ) -> tuple:
-    """Return explicit query-row records for one 128-column domain."""
-    states, imgt_start, first_row = alignment_to_states(alignment)
+    """Return query-row records, optionally restoring a reduced reference."""
+    states, imgt_start, first_row = alignment_to_states(
+        alignment,
+        ref_positions=ref_positions,
+    )
+    if ref_type is not None:
+        if ref_type not in MISSING_IMGT_POSITIONS:
+            raise ValueError("ref_type must be 'H', 'K', or 'L'.")
+        if ref_positions is not None:
+            missing_positions = frozenset(
+                range(1, constants.IMGT_MAX_POSITION + 1)
+            ).difference(ref_positions)
+            if missing_positions != MISSING_IMGT_POSITIONS[ref_type]:
+                raise ValueError(
+                    f"ref_positions do not match the {ref_type} reference."
+                )
+        states = _insert_missing_deletions(states, ref_type)
     padded_sequence = "-" * imgt_start + sequence[first_row:]
     numbered, start, end = _apply_scheme(
         states, padded_sequence, scheme, chain_type
@@ -137,10 +274,31 @@ def number_alignment(
     sequence: str,
     scheme: str,
     chain_type: str,
+    *,
+    ref_type: str | None = None,
+    ref_positions: tuple[int, ...] | None = None,
 ) -> tuple:
-    """Return explicit query-row-to-number records for one alignment."""
+    """Return query-row-to-number records for one alignment.
+
+    ``ref_type`` and ``ref_positions`` are opt-in metadata for reduced
+    single-domain references. Normal 128-column antibody and 256-column scFv
+    alignments leave them unset.
+    """
     if ":" not in chain_type:
-        return _number_domain_alignment(alignment, sequence, scheme, chain_type)
+        return _number_domain_alignment(
+            alignment,
+            sequence,
+            scheme,
+            chain_type,
+            ref_type=ref_type,
+            ref_positions=ref_positions,
+        )
+
+    if ref_type is not None or ref_positions is not None:
+        raise ValueError(
+            "Reference metadata is supported only for single-domain "
+            "alignments."
+        )
 
     chain_types = chain_type.split(":")
     expected_columns = len(chain_types) * constants.IMGT_MAX_POSITION

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -17,6 +17,7 @@ from sabr.alignment import (
     load_references,
 )
 from sabr.model import encode, load_parameters
+from sabr.numbering import MISSING_IMGT_POSITIONS
 from sabr.structure import extract_chain
 
 DATA = Path(__file__).parent / "data"
@@ -104,6 +105,20 @@ def test_every_noise_asset_has_all_chain_references():
         for embeddings, positions in references.values():
             assert embeddings.shape[1] == constants.EMBED_DIM
             assert embeddings.shape[0] == len(positions)
+
+
+def test_missing_imgt_metadata_matches_every_reference_asset():
+    reference_sets = [
+        load_references(level) for level in constants.NOISE_LEVELS
+    ]
+    reference_sets.append(load_references(0.0, "softalign"))
+
+    all_positions = frozenset(range(1, constants.IMGT_MAX_POSITION + 1))
+    for references in reference_sets:
+        for chain_type, (_, positions) in references.items():
+            assert all_positions.difference(positions) == (
+                MISSING_IMGT_POSITIONS[chain_type]
+            )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_numbering.py
+++ b/tests/test_numbering.py
@@ -46,6 +46,250 @@ def test_alignment_state_conversion_preserves_orphan_insertions():
     assert ((4, "d"), None) in states
 
 
+def test_reduced_reference_positions_control_states_and_padding(monkeypatch):
+    alignment = np.zeros((4, 4), dtype=int)
+    alignment[1, 1] = alignment[2, 2] = alignment[3, 3] = 1
+    ref_positions = (29, 30, 36, 37)
+
+    def fake_scheme(states, sequence, scheme, chain_type):
+        assert states == [
+            ((30, "m"), 29),
+            ((36, "m"), 30),
+            ((37, "m"), 31),
+        ]
+        assert sequence == "-" * 29 + "CDE"
+        return [((30, ""), "C"), ((36, ""), "D"), ((37, ""), "E")], 29, 31
+
+    monkeypatch.setattr(numbering, "_apply_scheme", fake_scheme)
+    assert number_alignment(
+        alignment,
+        "ACDE",
+        "imgt",
+        "H",
+        ref_positions=ref_positions,
+    ) == [
+        (1, 30, "", "C"),
+        (2, 36, "", "D"),
+        (3, 37, "", "E"),
+    ]
+
+
+def test_k_reduced_reference_expands_to_every_imgt_state(monkeypatch):
+    missing = numbering.MISSING_IMGT_POSITIONS["K"]
+    ref_positions = tuple(
+        position
+        for position in range(1, constants.IMGT_MAX_POSITION + 1)
+        if position not in missing
+    )
+    alignment = np.eye(len(ref_positions), dtype=int)
+    sequence = "A" * len(ref_positions)
+    captured = {}
+
+    def fake_scheme(states, padded_sequence, scheme, chain_type):
+        captured["states"] = states
+        matches = [state for state in states if state[0][1] == "m"]
+        return (
+            [
+                ((position, ""), padded_sequence[sequence_index])
+                for ((position, _), sequence_index) in matches
+            ],
+            0,
+            len(sequence) - 1,
+        )
+
+    monkeypatch.setattr(numbering, "_apply_scheme", fake_scheme)
+    records = number_alignment(
+        alignment,
+        sequence,
+        "imgt",
+        "A",
+        ref_type="K",
+        ref_positions=ref_positions,
+    )
+
+    states = captured["states"]
+    assert [state[0][0] for state in states] == list(
+        range(1, constants.IMGT_MAX_POSITION + 1)
+    )
+    assert {
+        position for ((position, state_type), _) in states if state_type == "d"
+    } == missing
+    assert len(records) == len(ref_positions)
+
+
+@pytest.mark.parametrize("chain_type", ("A", "B", "G", "D"))
+@pytest.mark.parametrize(
+    ("scheme", "last_number"), (("imgt", 127), ("aho", 148))
+)
+def test_reduced_k_reference_runs_real_tcr_numbering(
+    chain_type, scheme, last_number
+):
+    missing = numbering.MISSING_IMGT_POSITIONS["K"]
+    ref_positions = tuple(
+        position
+        for position in range(1, constants.IMGT_MAX_POSITION + 1)
+        if position not in missing
+    )
+    records = number_alignment(
+        np.eye(len(ref_positions), dtype=int),
+        "A" * len(ref_positions),
+        scheme,
+        chain_type,
+        ref_type="K",
+        ref_positions=ref_positions,
+    )
+
+    assert len(records) == len(ref_positions)
+    assert records[0][1] == 1
+    assert records[-1][1] == last_number
+
+
+def test_missing_deletion_insertion_is_idempotent_and_preserves_insertions():
+    states = [
+        ((9, "m"), 0),
+        ((9, "i"), 1),
+        ((11, "m"), 2),
+    ]
+    completed = numbering._insert_missing_deletions(states, "H")
+
+    assert numbering._insert_missing_deletions(completed, "H") is completed
+    assert [state for state in completed if state[0][0] == 9] == states[:2]
+    assert ((10, "d"), None) in completed
+
+    expanded = [
+        (
+            (
+                position,
+                (
+                    "d"
+                    if position in numbering.MISSING_IMGT_POSITIONS["K"]
+                    else "m"
+                ),
+            ),
+            None,
+        )
+        for position in range(1, constants.IMGT_MAX_POSITION + 1)
+    ]
+    assert numbering._insert_missing_deletions(expanded, "K") is expanded
+
+
+@pytest.mark.parametrize(
+    ("ref_positions", "message"),
+    [
+        ([1, 2], "tuple"),
+        ((1,), "column count"),
+        ((1, True), "integers"),
+        ((0, 2), "between"),
+        ((1, 129), "between"),
+        ((2, 1), "increasing"),
+        ((1, 1), "increasing"),
+    ],
+)
+def test_reduced_reference_positions_are_validated(ref_positions, message):
+    with pytest.raises(ValueError, match=message):
+        alignment_to_states(np.eye(2, dtype=int), ref_positions=ref_positions)
+
+
+@pytest.mark.parametrize("chain_type", ("A", "B", "G", "D"))
+def test_low_level_tcr_aho_uses_the_actual_chain_type(monkeypatch, chain_type):
+    alignment = np.zeros((1, constants.IMGT_MAX_POSITION), dtype=int)
+    alignment[0, 0] = 1
+
+    def fake_aho(states, sequence, actual_chain_type):
+        assert actual_chain_type == chain_type
+        assert {
+            position
+            for ((position, state_type), _) in states
+            if state_type == "d"
+        } == numbering.MISSING_IMGT_POSITIONS["K"]
+        return [((1, ""), "A")], 0, 0
+
+    monkeypatch.setattr(numbering.schemes, "number_aho", fake_aho)
+    assert number_alignment(
+        alignment,
+        "A",
+        "aho",
+        chain_type,
+        ref_type="K",
+    ) == [(0, 1, "", "A")]
+
+
+def test_low_level_tcr_imgt_numbering_is_available(monkeypatch):
+    alignment = np.zeros((1, constants.IMGT_MAX_POSITION), dtype=int)
+    alignment[0, 0] = 1
+    monkeypatch.setattr(
+        numbering.schemes,
+        "number_imgt",
+        lambda states, sequence: ([((1, ""), "A")], 0, 0),
+    )
+    assert number_alignment(
+        alignment,
+        "A",
+        "imgt",
+        "A",
+        ref_type="K",
+    ) == [(0, 1, "", "A")]
+
+
+@pytest.mark.parametrize("chain_type", ("A", "B", "G", "D"))
+@pytest.mark.parametrize("scheme", ("chothia", "kabat", "martin", "wolfguy"))
+def test_tcr_chain_types_reject_antibody_only_schemes(chain_type, scheme):
+    with pytest.raises(ValueError, match="only IMGT or AHo"):
+        numbering._apply_scheme([], "", scheme, chain_type)
+
+
+def test_reference_metadata_rejects_invalid_or_ambiguous_combinations():
+    with pytest.raises(ValueError, match="ref_type"):
+        number_alignment(
+            np.eye(2, dtype=int),
+            "AC",
+            "imgt",
+            "H",
+            ref_type="A",
+        )
+    with pytest.raises(ValueError, match="do not match"):
+        number_alignment(
+            np.eye(2, dtype=int),
+            "AC",
+            "imgt",
+            "H",
+            ref_type="K",
+            ref_positions=(1, 2),
+        )
+    with pytest.raises(ValueError, match="single-domain"):
+        number_alignment(
+            np.eye(2, dtype=int),
+            "AC",
+            "imgt",
+            "H:K",
+            ref_type="K",
+        )
+
+
+@pytest.mark.parametrize("chain_type", constants.CHAIN_TYPES)
+def test_default_single_domain_numbering_skips_reference_completion(
+    monkeypatch, chain_type
+):
+    monkeypatch.setattr(
+        numbering,
+        "_insert_missing_deletions",
+        lambda *args: pytest.fail("default path completed reference states"),
+    )
+    monkeypatch.setattr(
+        numbering,
+        "_apply_scheme",
+        lambda states, sequence, scheme, actual_type: (
+            [((1, ""), "A"), ((2, ""), "C")],
+            0,
+            1,
+        ),
+    )
+    assert number_alignment(np.eye(2, dtype=int), "AC", "imgt", chain_type) == [
+        (0, 1, "", "A"),
+        (1, 2, "", "C"),
+    ]
+
+
 def test_8sve_huge_cdr1_matches_the_accepted_full_mapping():
     golden = json.loads((DATA / "8sve_cdr1_imgt.json").read_text())
     structure = PDBParser(QUIET=True).get_structure("long", DATA / "8sve_L.pdb")
@@ -113,6 +357,11 @@ def test_scfv_numbering_offsets_second_domain_and_numbers_linker(monkeypatch):
             return [((1, ""), "A"), ((2, ""), "C")], 0, 1
         return [((1, ""), "E"), ((2, ""), "F")], 0, 1
 
+    monkeypatch.setattr(
+        numbering,
+        "_insert_missing_deletions",
+        lambda *args: pytest.fail("scFv path completed reference states"),
+    )
     monkeypatch.setattr(numbering, "_apply_scheme", fake_scheme)
     assert number_alignment(alignment, "ACDEF", "imgt", "H:K") == [
         (0, 1, "", "A"),

--- a/tests/test_numbering.py
+++ b/tests/test_numbering.py
@@ -272,6 +272,11 @@ def test_default_single_domain_numbering_skips_reference_completion(
 ):
     monkeypatch.setattr(
         numbering,
+        "_load_missing_imgt_positions",
+        lambda: pytest.fail("default path loaded reference metadata"),
+    )
+    monkeypatch.setattr(
+        numbering,
         "_insert_missing_deletions",
         lambda *args: pytest.fail("default path completed reference states"),
     )
@@ -357,6 +362,11 @@ def test_scfv_numbering_offsets_second_domain_and_numbers_linker(monkeypatch):
             return [((1, ""), "A"), ((2, ""), "C")], 0, 1
         return [((1, ""), "E"), ((2, ""), "F")], 0, 1
 
+    monkeypatch.setattr(
+        numbering,
+        "_load_missing_imgt_positions",
+        lambda: pytest.fail("scFv path loaded reference metadata"),
+    )
     monkeypatch.setattr(
         numbering,
         "_insert_missing_deletions",


### PR DESCRIPTION
## Summary

- map reduced reference-alignment columns back to their actual IMGT positions and restore omitted deletion states idempotently
- allow the explicit low-level A/B/G/D IMGT/AHo workaround through K references without expanding official TCR, CLI, automatic-classification, or public supported-chain behavior
- validate H/K/L reference assets, reduced-column edge cases, scFv ambiguity, and unchanged default-path helper/model-call behavior
- document the experimental, unsupported TCR workflow

## Testing

- pre-commit run --all-files
- JAX_PLATFORMS=cpu pytest --cov=sabr --cov-report=term-missing -q — 148 passed, 96.39% coverage

Closes #192