### PR TITLE
Integrate universal deterministic DE-loop correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,8 +131,8 @@ the CLI with mmCIF output.
   In `softalign` mode, they are `0.1942468136548996` and
   `-2.5441808700561523`, respectively, as stored in the repository asset.
 - Deterministic CDR gap distribution and DE-loop correction are always
-  applied. DE-loop residues between IMGT 80 and 83 are assigned from their
-  count, with additional insertions placed on 82.
+  applied. Between IMGT anchors 79 and 85, DE-loop residues fill 80 first,
+  then 84 back through 81; additional residues are inserted after 82.
 - No deterministic C-terminal correction is applied.
 - Automatic chain selection aligns against H, K, and L references and uses
   the highest score, with deterministic H/K/L tie order.

--- a/README.md
+++ b/README.md
@@ -130,8 +130,10 @@ the CLI with mmCIF output.
 - In `sabr` mode, gap extension is `-0.175027` and gap opening is `-2.525591`.
   In `softalign` mode, they are `0.1942468136548996` and
   `-2.5441808700561523`, respectively, as stored in the repository asset.
-- CDR gap distribution is always applied.
-- No deterministic light-chain DE-loop or C-terminal correction is applied.
+- Deterministic CDR gap distribution and DE-loop correction are always
+  applied. DE-loop residues between IMGT 80 and 83 are assigned from their
+  count, with additional insertions placed on 82.
+- No deterministic C-terminal correction is applied.
 - Automatic chain selection aligns against H, K, and L references and uses
   the highest score, with deterministic H/K/L tie order.
 - scFv mode appends H:K, H:L, K:H, and L:H reference candidates in that order.
@@ -140,8 +142,8 @@ the CLI with mmCIF output.
   compared; the underlying alignments and raw alignment scores are unchanged.
 
 A structural gap is detected when the C–N distance between consecutive
-residues exceeds 2.66 Å. A gap skips only the affected CDR correction and
-emits a warning; other regions continue normally.
+residues exceeds 2.66 Å. A gap skips only the affected CDR or DE-loop
+correction and emits a warning; other regions continue normally.
 
 T-cell receptors are not an officially supported SAbR target. For
 experimental low-level use, align a TCR against the K reference because that

--- a/docs/index.md
+++ b/docs/index.md
@@ -158,8 +158,9 @@ are required.
 ## Structural gaps and modified residues
 
 A C–N distance above 2.66 Å is treated as a structural gap. If a gap crosses a
-CDR, SAbR warns and retains the learned alignment for that region while
-continuing corrections elsewhere.
+CDR or the DE loop between IMGT 80 and 83, SAbR warns and retains the learned
+alignment for that region while continuing corrections elsewhere. Otherwise,
+DE-loop residues are assigned by count, with additional insertions on 82.
 
 Supported modified peptide residues are translated to their canonical parent
 only for sequence generation. Original residue names and atoms are preserved.

--- a/docs/index.md
+++ b/docs/index.md
@@ -158,9 +158,10 @@ are required.
 ## Structural gaps and modified residues
 
 A C–N distance above 2.66 Å is treated as a structural gap. If a gap crosses a
-CDR or the DE loop between IMGT 80 and 83, SAbR warns and retains the learned
-alignment for that region while continuing corrections elsewhere. Otherwise,
-DE-loop residues are assigned by count, with additional insertions on 82.
+CDR or the DE loop between IMGT anchors 79 and 85, SAbR warns and retains the
+learned alignment for that region while continuing corrections elsewhere.
+Otherwise, DE-loop residues fill 80 first, then 84 back through 81; additional
+residues are inserted after 82.
 
 Supported modified peptide residues are translated to their canonical parent
 only for sequence generation. Original residue names and atoms are preserved.

--- a/src/sabr/alignment.py
+++ b/src/sabr/alignment.py
@@ -232,7 +232,7 @@ def _validate_alignment(alignment: np.ndarray, chain_type: str) -> None:
             "use residue_range to select the antibody domain."
         )
 
-    regions = [*constants.IMGT_LOOPS.values(), (79, 84)]
+    regions = [*constants.IMGT_LOOPS.values(), (79, 85)]
     for index, (left_row, right_row) in enumerate(zip(rows, rows[1:])):
         if right_row == left_row + 1:
             continue

--- a/src/sabr/alignment.py
+++ b/src/sabr/alignment.py
@@ -232,9 +232,7 @@ def _validate_alignment(alignment: np.ndarray, chain_type: str) -> None:
             "use residue_range to select the antibody domain."
         )
 
-    regions = list(constants.IMGT_LOOPS.values())
-    if chain_type in ("K", "L"):
-        regions.append((79, 84))
+    regions = [*constants.IMGT_LOOPS.values(), (79, 84)]
     for index, (left_row, right_row) in enumerate(zip(rows, rows[1:])):
         if right_row == left_row + 1:
             continue

--- a/src/sabr/corrections.py
+++ b/src/sabr/corrections.py
@@ -1,4 +1,4 @@
-"""Deterministic CDR corrections."""
+"""Deterministic CDR and DE-loop corrections."""
 
 import logging
 import warnings
@@ -143,14 +143,77 @@ def correct_cdr_loop(
     return aln
 
 
+def de_loop_positions(n_residues: int) -> list[int]:
+    """Return IMGT positions for residues between anchors 80 and 83.
+
+    The SAbDab consensus skips 81 for a one-residue loop, uses 81 and 82
+    for a two-residue loop, and places any additional insertions on 82.
+    """
+    if n_residues == 0:
+        return []
+    if n_residues == 1:
+        return [82]
+    return [81, 82] + [82] * (n_residues - 2)
+
+
+def correct_de_loop(
+    aln: np.ndarray,
+    gap_indices: frozenset[int] | None = None,
+) -> np.ndarray:
+    """Assign the residues between IMGT 80 and 83 by loop length."""
+    anchor_80_row = _aligned_row_near(aln, 79)
+    anchor_83_row = _aligned_row_near(aln, 82)
+
+    if anchor_80_row is None or anchor_83_row is None:
+        LOGGER.warning(
+            "Skipping DE loop correction; missing anchor near IMGT 80 or 83."
+        )
+        return aln
+    if anchor_80_row >= anchor_83_row:
+        LOGGER.warning(
+            "Skipping DE loop correction; anchor 80 row (%d) is not before "
+            "anchor 83 row (%d).",
+            anchor_80_row,
+            anchor_83_row,
+        )
+        return aln
+    if _skip_for_structural_gap(
+        gap_indices, anchor_80_row, anchor_83_row, "DE loop (80-83)"
+    ):
+        return aln
+
+    intermediate_rows = list(range(anchor_80_row + 1, anchor_83_row))
+    positions = de_loop_positions(len(intermediate_rows))
+
+    # Clear the learned assignments for this region before rebuilding it.
+    # Additional occurrences of 82 remain unassigned here; alignment_to_states
+    # converts those orphan rows to 82A, 82B, and later insertion states.
+    aln[intermediate_rows, :] = 0
+    assigned_positions = set()
+    for row, position in zip(intermediate_rows, positions):
+        if position in assigned_positions:
+            continue
+        aln[row, position - 1] = 1
+        assigned_positions.add(position)
+
+    if intermediate_rows:
+        LOGGER.info(
+            "DE loop correction: assigned %d residue(s) to %s.",
+            len(intermediate_rows),
+            positions,
+        )
+    return aln
+
+
 def apply_corrections(
     aln: np.ndarray,
     gap_indices: frozenset[int] | None = None,
 ) -> np.ndarray:
-    """Apply deterministic CDR corrections."""
+    """Apply deterministic CDR and DE-loop corrections."""
     for loop_name, (cdr_start, cdr_end) in constants.IMGT_LOOPS.items():
         correct_cdr_loop(
             aln, loop_name, cdr_start, cdr_end, gap_indices=gap_indices
         )
 
+    correct_de_loop(aln, gap_indices=gap_indices)
     return aln

--- a/src/sabr/corrections.py
+++ b/src/sabr/corrections.py
@@ -144,45 +144,46 @@ def correct_cdr_loop(
 
 
 def de_loop_positions(n_residues: int) -> list[int]:
-    """Return IMGT positions for residues between anchors 80 and 83.
+    """Return IMGT positions for residues between anchors 79 and 85.
 
-    The SAbDab consensus skips 81 for a one-residue loop, uses 81 and 82
-    for a two-residue loop, and places any additional insertions on 82.
+    Position 80 is filled first, followed by positions 84 through 81 from
+    right to left. Once positions 80 through 84 are occupied, additional
+    residues become insertions on position 82.
     """
-    if n_residues == 0:
+    if n_residues <= 0:
         return []
-    if n_residues == 1:
-        return [82]
-    return [81, 82] + [82] * (n_residues - 2)
+    if n_residues <= 5:
+        return [80, *range(86 - n_residues, 85)]
+    return [80, 81, 82, *([82] * (n_residues - 5)), 83, 84]
 
 
 def correct_de_loop(
     aln: np.ndarray,
     gap_indices: frozenset[int] | None = None,
 ) -> np.ndarray:
-    """Assign the residues between IMGT 80 and 83 by loop length."""
-    anchor_80_row = _aligned_row_near(aln, 79)
-    anchor_83_row = _aligned_row_near(aln, 82)
+    """Assign the residues between IMGT 79 and 85 by loop length."""
+    anchor_79_row = _aligned_row_near(aln, 78)
+    anchor_85_row = _aligned_row_near(aln, 84)
 
-    if anchor_80_row is None or anchor_83_row is None:
+    if anchor_79_row is None or anchor_85_row is None:
         LOGGER.warning(
-            "Skipping DE loop correction; missing anchor near IMGT 80 or 83."
+            "Skipping DE loop correction; missing anchor near IMGT 79 or 85."
         )
         return aln
-    if anchor_80_row >= anchor_83_row:
+    if anchor_79_row >= anchor_85_row:
         LOGGER.warning(
-            "Skipping DE loop correction; anchor 80 row (%d) is not before "
-            "anchor 83 row (%d).",
-            anchor_80_row,
-            anchor_83_row,
+            "Skipping DE loop correction; anchor 79 row (%d) is not before "
+            "anchor 85 row (%d).",
+            anchor_79_row,
+            anchor_85_row,
         )
         return aln
     if _skip_for_structural_gap(
-        gap_indices, anchor_80_row, anchor_83_row, "DE loop (80-83)"
+        gap_indices, anchor_79_row, anchor_85_row, "DE loop (79-85)"
     ):
         return aln
 
-    intermediate_rows = list(range(anchor_80_row + 1, anchor_83_row))
+    intermediate_rows = list(range(anchor_79_row + 1, anchor_85_row))
     positions = de_loop_positions(len(intermediate_rows))
 
     # Clear the learned assignments for this region before rebuilding it.

--- a/tests/test_corrections.py
+++ b/tests/test_corrections.py
@@ -7,7 +7,10 @@ from sabr.corrections import (
     apply_corrections,
     cdr_columns,
     correct_cdr_loop,
+    correct_de_loop,
+    de_loop_positions,
 )
+from sabr.numbering import alignment_to_states
 
 
 @pytest.mark.parametrize(
@@ -88,7 +91,63 @@ def test_gap_outside_corrected_regions_emits_no_warning():
     assert captured == []
 
 
-def test_de_loop_and_c_terminus_keep_the_learned_alignment():
+@pytest.mark.parametrize(
+    ("residue_count", "expected"),
+    [
+        (0, []),
+        (1, [82]),
+        (2, [81, 82]),
+        (4, [81, 82, 82, 82]),
+    ],
+)
+def test_de_loop_positions_follow_sabdab_consensus(residue_count, expected):
+    assert de_loop_positions(residue_count) == expected
+
+
+@pytest.mark.parametrize("residue_count", (0, 1, 2, 4))
+def test_de_loop_is_rebuilt_between_80_and_83(residue_count):
+    alignment = np.zeros((residue_count + 2, 128), dtype=int)
+    alignment[0, 79] = 1
+    alignment[-1, 82] = 1
+    for row in range(1, residue_count + 1):
+        alignment[row, 79] = 1
+
+    corrected = correct_de_loop(alignment)
+    expected = np.zeros_like(alignment)
+    expected[0, 79] = 1
+    expected[-1, 82] = 1
+    if residue_count == 1:
+        expected[1, 81] = 1
+    elif residue_count >= 2:
+        expected[1, 80] = 1
+        expected[2, 81] = 1
+    np.testing.assert_array_equal(corrected, expected)
+
+    states, _, _ = alignment_to_states(corrected)
+    expected_82_states = (
+        [(82, "d")]
+        if residue_count == 0
+        else [(82, "m"), *((82, "i"),) * max(0, residue_count - 2)]
+    )
+    assert [state for state, _ in states if state[0] == 82] == (
+        expected_82_states
+    )
+
+
+def test_structural_gap_skips_de_loop_correction():
+    alignment = np.zeros((4, 128), dtype=int)
+    alignment[0, 79] = 1
+    alignment[1, 80] = 1
+    alignment[2, 81] = 1
+    alignment[3, 82] = 1
+    original = alignment.copy()
+
+    with pytest.warns(UserWarning, match=r"Skipping DE loop \(80-83\)"):
+        corrected = correct_de_loop(alignment, gap_indices=frozenset({1}))
+    np.testing.assert_array_equal(corrected, original)
+
+
+def test_standard_de_loop_keeps_the_learned_alignment():
     alignment = np.zeros((130, 128), dtype=int)
     for row in range(125):
         alignment[row, row] = 1

--- a/tests/test_corrections.py
+++ b/tests/test_corrections.py
@@ -10,7 +10,7 @@ from sabr.corrections import (
     correct_de_loop,
     de_loop_positions,
 )
-from sabr.numbering import alignment_to_states
+from sabr.numbering import alignment_to_states, number_alignment
 
 
 @pytest.mark.parametrize(
@@ -95,54 +95,84 @@ def test_gap_outside_corrected_regions_emits_no_warning():
     ("residue_count", "expected"),
     [
         (0, []),
-        (1, [82]),
-        (2, [81, 82]),
-        (4, [81, 82, 82, 82]),
+        (1, [80]),
+        (2, [80, 84]),
+        (3, [80, 83, 84]),
+        (4, [80, 82, 83, 84]),
+        (5, [80, 81, 82, 83, 84]),
+        (6, [80, 81, 82, 82, 83, 84]),
     ],
 )
-def test_de_loop_positions_follow_sabdab_consensus(residue_count, expected):
+def test_de_loop_positions_follow_imgt_79_85_convention(
+    residue_count, expected
+):
     assert de_loop_positions(residue_count) == expected
 
 
-@pytest.mark.parametrize("residue_count", (0, 1, 2, 4))
-def test_de_loop_is_rebuilt_between_80_and_83(residue_count):
+@pytest.mark.parametrize(
+    ("expected_columns", "expected_82_states"),
+    [
+        ([], [(82, "d")]),
+        ([79], [(82, "d")]),
+        ([79, 83], [(82, "d")]),
+        ([79, 82, 83], [(82, "d")]),
+        ([79, 81, 82, 83], [(82, "m")]),
+        ([79, 80, 81, 82, 83], [(82, "m")]),
+        ([79, 80, 81, None, 82, 83], [(82, "m"), (82, "i")]),
+    ],
+)
+def test_de_loop_is_rebuilt_between_79_and_85(
+    expected_columns, expected_82_states
+):
+    residue_count = len(expected_columns)
     alignment = np.zeros((residue_count + 2, 128), dtype=int)
-    alignment[0, 79] = 1
-    alignment[-1, 82] = 1
+    alignment[0, 78] = 1
+    alignment[-1, 84] = 1
     for row in range(1, residue_count + 1):
-        alignment[row, 79] = 1
+        alignment[row, 78] = 1
 
     corrected = correct_de_loop(alignment)
     expected = np.zeros_like(alignment)
-    expected[0, 79] = 1
-    expected[-1, 82] = 1
-    if residue_count == 1:
-        expected[1, 81] = 1
-    elif residue_count >= 2:
-        expected[1, 80] = 1
-        expected[2, 81] = 1
+    expected[0, 78] = 1
+    expected[-1, 84] = 1
+    for row, column in enumerate(expected_columns, start=1):
+        if column is not None:
+            expected[row, column] = 1
     np.testing.assert_array_equal(corrected, expected)
 
     states, _, _ = alignment_to_states(corrected)
-    expected_82_states = (
-        [(82, "d")]
-        if residue_count == 0
-        else [(82, "m"), *((82, "i"),) * max(0, residue_count - 2)]
-    )
     assert [state for state, _ in states if state[0] == 82] == (
         expected_82_states
     )
 
 
+def test_six_residue_de_loop_numbers_the_insertion_as_82a():
+    alignment = np.zeros((8, 128), dtype=int)
+    alignment[0, 78] = 1
+    alignment[-1, 84] = 1
+    alignment[1:7, 78] = 1
+
+    records = number_alignment(correct_de_loop(alignment), "A" * 8, "imgt", "H")
+
+    assert [(number, code.strip()) for _, number, code, _ in records] == [
+        (79, ""),
+        (80, ""),
+        (81, ""),
+        (82, ""),
+        (82, "A"),
+        (83, ""),
+        (84, ""),
+        (85, ""),
+    ]
+
+
 def test_structural_gap_skips_de_loop_correction():
-    alignment = np.zeros((4, 128), dtype=int)
-    alignment[0, 79] = 1
-    alignment[1, 80] = 1
-    alignment[2, 81] = 1
-    alignment[3, 82] = 1
+    alignment = np.zeros((7, 128), dtype=int)
+    for row, position in enumerate(range(79, 86)):
+        alignment[row, position - 1] = 1
     original = alignment.copy()
 
-    with pytest.warns(UserWarning, match=r"Skipping DE loop \(80-83\)"):
+    with pytest.warns(UserWarning, match=r"Skipping DE loop \(79-85\)"):
         corrected = correct_de_loop(alignment, gap_indices=frozenset({1}))
     np.testing.assert_array_equal(corrected, original)
 

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -358,11 +358,14 @@ def test_huge_internal_run_is_valid_inside_one_cdr():
 
 @pytest.mark.parametrize("chain_type", constants.CHAIN_TYPES)
 def test_de_loop_insertions_are_valid_for_every_chain_type(chain_type):
-    alignment = np.zeros((5, 128), dtype=int)
-    alignment[0, 79] = 1
-    alignment[1, 80] = 1
-    alignment[2, 81] = 1
-    alignment[4, 82] = 1
+    alignment = np.zeros((8, 128), dtype=int)
+    alignment[0, 78] = 1
+    alignment[1, 79] = 1
+    alignment[2, 80] = 1
+    alignment[3, 81] = 1
+    alignment[5, 82] = 1
+    alignment[6, 83] = 1
+    alignment[7, 84] = 1
     _validate_alignment(alignment, chain_type)
 
 

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -356,6 +356,16 @@ def test_huge_internal_run_is_valid_inside_one_cdr():
     _validate_alignment(alignment, "K")
 
 
+@pytest.mark.parametrize("chain_type", constants.CHAIN_TYPES)
+def test_de_loop_insertions_are_valid_for_every_chain_type(chain_type):
+    alignment = np.zeros((5, 128), dtype=int)
+    alignment[0, 79] = 1
+    alignment[1, 80] = 1
+    alignment[2, 81] = 1
+    alignment[4, 82] = 1
+    _validate_alignment(alignment, chain_type)
+
+
 @pytest.mark.parametrize(
     ("alignment", "message"),
     [


### PR DESCRIPTION
## Summary

- integrate the deterministic DE-loop correction from `ddelalamo-takeda/SAbR@bf90b5e`
- use IMGT 79 and 85 as anchors and assign intervening residues by count: position 80 first, then positions 84 through 81 from right to left, with additional insertions on 82
- preserve compatibility with the current strict alignment representation by converting additional occurrences of 82 into orphan-row insertion states
- skip only the DE-loop correction when a structural gap crosses the region
- document the updated scientific behavior and structural-gap handling

## Integration notes

The source branch predates the current SoftAlign and reduced-reference alignment APIs. Its unrelated `_align_reference(..., positions)` call-site fix was therefore not applied; current `main` correctly passes `mode` there. The DE-loop implementation was adapted to the current validator so 82A/82B insertions remain valid and monotonic.

## Testing

- `JAX_PLATFORMS=cpu pytest -q tests/test_corrections.py tests/test_math.py` — 55 passed
- `JAX_PLATFORMS=cpu pytest --cov=sabr --cov-report=term-missing -q` — 167 passed, 95.98% coverage
- `pre-commit run --all-files` — Black, isort, and Flake8 passed
