### PR TITLE
Remove scFv linker gap penalties

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ the CLI with mmCIF output.
 - Automatic chain selection aligns against H, K, and L references and uses
   the highest score, with deterministic H/K/L tie order.
 - scFv mode appends H:K, H:L, K:H, and L:H reference candidates in that order.
+- Composite candidates do not apply gap-open or gap-extension costs to query
+  linker residues aligned at the boundary between their two references.
 - Composite candidates receive normal affine gap-open and gap-extension costs
   for unaligned query and reference termini when their selection scores are
   compared; the underlying alignments and raw alignment scores are unchanged.

--- a/docs/index.md
+++ b/docs/index.md
@@ -72,6 +72,9 @@ scFv mode requires the default automatic chain type because each composite
 reference already specifies both domain types.
 Composite references use the selected parameter mode, so `--scfv` can be
 combined with `--mode softalign`.
+Gap-open and gap-extension penalties are disabled for query linker residues
+aligned at the boundary between the two references. All other internal gap
+transitions retain the selected parameter mode's normal penalties.
 
 When candidates are compared, SAbR applies the normal affine gap-open and
 gap-extension costs to unaligned query and reference termini of composite

--- a/src/sabr/alignment.py
+++ b/src/sabr/alignment.py
@@ -15,16 +15,18 @@ from sabr.corrections import apply_corrections
 LOGGER = logging.getLogger(__name__)
 
 
-def _rotate_for_dp(x, NINF):
+def _rotate_for_dp(x, NINF, free_gap_boundary=-1):
     """Rotate a matrix for striped dynamic programming."""
     a, b = x.shape
     ar = jnp.arange(a)[::-1, None]
     br = jnp.arange(b)[None, :]
     i, j = (br - ar) + (a - 1), (ar + br) // 2
     n, m = (a + b - 1), (a + b) // 2
+    free_gap = jnp.broadcast_to(br == free_gap_boundary, (a, b))
     output = {
         "x": jnp.full([n, m], NINF).at[i, j].set(x),
         "o": (jnp.arange(n) + a % 2) % 2,
+        "free_gap": jnp.full([n, m], False).at[i, j].set(free_gap),
     }
     prev = (jnp.full((m, 3), NINF), jnp.full((m, 3), NINF))
     return output, prev, (i, j)
@@ -71,9 +73,10 @@ def _affine_score(
     temperature,
     gap_extend,
     gap_open,
+    free_gap_boundary=-1,
     NINF=-1e30,
 ):
-    """Return the smooth affine Smith-Waterman score for one matrix."""
+    """Return a score, optionally making one reference gap boundary free."""
     right_penalties = jnp.asarray(
         [
             gap_open,
@@ -105,7 +108,11 @@ def _affine_score(
             _pad(h1[1:], ([0, 1], [0, 0]), NINF),
         )
         right += right_penalties
-        down += down_penalties
+        down += jnp.where(
+            stripe["free_gap"][:, None],
+            0,
+            down_penalties,
+        )
         right = right[:, :2]
 
         h0 = jnp.stack(
@@ -119,7 +126,9 @@ def _affine_score(
         return (h1, h0), h0
 
     similarities, mask = _apply_length_mask(similarities, lengths, NINF)
-    stripes, previous, indices = _rotate_for_dp(similarities[:-1, :-1], NINF)
+    stripes, previous, indices = _rotate_for_dp(
+        similarities[:-1, :-1], NINF, free_gap_boundary
+    )
     scores = jax.lax.scan(step, previous, stripes, unroll=2)[-1][indices]
     return _soft_maximum(
         scores + similarities[1:, 1:, None],
@@ -130,7 +139,10 @@ def _affine_score(
 
 
 _AFFINE_ALIGNMENT = jax.jit(
-    jax.vmap(jax.value_and_grad(_affine_score), (0, 0, None, None, None))
+    jax.vmap(
+        jax.value_and_grad(_affine_score),
+        (0, 0, None, None, None, None),
+    )
 )
 
 
@@ -295,7 +307,9 @@ def _align_reference(
     query: np.ndarray,
     reference: np.ndarray,
     mode: str = "sabr",
+    free_gap_boundary: int = -1,
 ):
+    """Align one reference, optionally allowing a free query insertion."""
     anchor = np.zeros((1, reference.shape[1]), dtype=reference.dtype)
     augmented_reference = np.concatenate((anchor, reference, anchor), axis=0)
     query_batch = jnp.asarray(query[None, :])
@@ -309,6 +323,7 @@ def _align_reference(
         constants.DEFAULT_TEMPERATURE,
         gap_extend,
         gap_open,
+        free_gap_boundary,
     )
     return (
         np.asarray(soft_alignment[0])[:, 1:-1],
@@ -367,7 +382,21 @@ def align(
     best = None
     for candidate in candidates:
         reference, positions = references[candidate]
-        reduced, similarity, score = _align_reference(query, reference, mode)
+        if ":" in candidate:
+            free_gap_boundary = sum(
+                position <= constants.IMGT_MAX_POSITION
+                for position in positions
+            )
+            reduced, similarity, score = _align_reference(
+                query,
+                reference,
+                mode,
+                free_gap_boundary=free_gap_boundary,
+            )
+        else:
+            reduced, similarity, score = _align_reference(
+                query, reference, mode
+            )
         if (
             not np.isfinite(score)
             or not np.isfinite(reduced).all()

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -8,6 +8,7 @@ import pytest
 from sabr import constants
 from sabr.alignment import (
     _affine_gap_penalty,
+    _affine_score,
     _align_reference,
     _terminal_gap_penalty,
     _validate_alignment,
@@ -159,6 +160,38 @@ def test_scfv_alignment_allows_an_unassigned_linker_between_domains():
     _validate_scfv_alignment(alignment, "H:K")
 
 
+@pytest.mark.parametrize("linker_length", (1, 3))
+def test_scfv_reference_boundary_has_no_affine_linker_penalty(linker_length):
+    query_length = linker_length + 2
+    similarities = np.full((query_length, 4), -100.0, dtype=np.float32)
+    similarities[:, (0, 3)] = 0.0
+    similarities[0, 1] = 10.0
+    similarities[-1, 2] = 10.0
+    lengths = np.asarray((query_length, similarities.shape[1]))
+    gap_extend = -1.0
+    gap_open = -3.0
+
+    penalized = _affine_score(
+        similarities,
+        lengths,
+        1e-4,
+        gap_extend,
+        gap_open,
+    )
+    free = _affine_score(
+        similarities,
+        lengths,
+        1e-4,
+        gap_extend,
+        gap_open,
+        free_gap_boundary=1,
+    )
+
+    expected_penalty = gap_open + (linker_length - 1) * gap_extend
+    assert float(penalized) == pytest.approx(20.0 + expected_penalty)
+    assert float(free) == pytest.approx(20.0)
+
+
 def test_softalign_mode_loads_its_complete_parameter_set():
     references = load_references(2.0, "softalign")
     assert tuple(references) == constants.CHAIN_TYPES
@@ -177,9 +210,17 @@ def test_softalign_mode_loads_its_complete_parameter_set():
 def test_softalign_gap_penalties_reach_affine_alignment(monkeypatch):
     captured = {}
 
-    def fake_affine(similarity, lengths, temperature, gap_extend, gap_open):
+    def fake_affine(
+        similarity,
+        lengths,
+        temperature,
+        gap_extend,
+        gap_open,
+        free_gap_boundary,
+    ):
         captured["gap_extend"] = gap_extend
         captured["gap_open"] = gap_open
+        captured["free_gap_boundary"] = free_gap_boundary
         return np.asarray([0.0]), np.zeros(np.asarray(similarity).shape)
 
     monkeypatch.setattr("sabr.alignment._AFFINE_ALIGNMENT", fake_affine)
@@ -191,6 +232,7 @@ def test_softalign_gap_penalties_reach_affine_alignment(monkeypatch):
     assert captured == {
         "gap_extend": pytest.approx(0.1942468136548996),
         "gap_open": pytest.approx(-2.5441808700561523),
+        "free_gap_boundary": -1,
     }
 
 
@@ -271,11 +313,15 @@ def test_scfv_mode_selects_and_corrects_a_composite_reference(monkeypatch):
             [1, 129] if domain_count == 2 else [1],
         )
 
-    def fake_align(query, reference, mode):
+    seen_boundaries = {}
+
+    def fake_align(query, reference, mode, free_gap_boundary=-1):
         reduced = np.zeros((len(query), len(reference)))
         np.fill_diagonal(reduced, 1)
         marker = int(reference[0, 0])
-        score = 10.0 if representations[marker] == "H:K" else 1.0
+        representation = representations[marker]
+        seen_boundaries[representation] = free_gap_boundary
+        score = 10.0 if representation == "H:K" else 1.0
         return reduced, np.zeros((len(query), len(reference) + 2)), score
 
     corrected_shapes = []
@@ -298,6 +344,15 @@ def test_scfv_mode_selects_and_corrects_a_composite_reference(monkeypatch):
     assert score == 10.0
     assert alignment.shape == (2, 256)
     assert corrected_shapes == [(2, 128), (2, 128)]
+    assert seen_boundaries == {
+        "H": -1,
+        "K": -1,
+        "L": -1,
+        "H:K": 1,
+        "H:L": 1,
+        "K:H": 1,
+        "L:H": 1,
+    }
 
 
 def test_terminal_gap_penalty_uses_normal_affine_gap_costs():
@@ -322,7 +377,7 @@ def test_scfv_terminal_penalty_is_used_only_for_candidate_selection(
         "H:K": (np.ones((4, 64)), [1, 2, 129, 130]),
     }
 
-    def fake_align(query, reference, mode):
+    def fake_align(query, reference, mode, free_gap_boundary=-1):
         if len(reference) == 1:
             return np.ones((1, 1)), np.zeros((1, 3)), 8.0
         return (


### PR DESCRIPTION
## Summary

- make gap-open and gap-extension transitions free for query linker residues at the boundary between concatenated scFv reference embeddings
- retain normal affine penalties for single-domain candidates and all other gap transitions
- document the scFv behavior and add regression coverage for both gap opening and extension

## Testing

- python -m pytest -q — 150 passed
- python -m pytest --cov=src/sabr --cov-report=term-missing -q — 96.27% coverage
- pre-commit run --all-files — passed