### PR TITLE
Streamline numbering and structure internals

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,6 @@ on:
 permissions:
   contents: read
 
-# CI validates source builds rather than release version inference. A CI-only
-# pretend version also keeps PR merge refs installable when the nearest tag is
-# a numbered development release such as v0.4.3.dev1.
-env:
-  SETUPTOOLS_SCM_PRETEND_VERSION: "0.0.0.dev${{ github.run_number }}"
-
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,12 @@ on:
 permissions:
   contents: read
 
+# CI validates source builds rather than release version inference. A CI-only
+# pretend version also keeps PR merge refs installable when the nearest tag is
+# a numbered development release such as v0.4.3.dev1.
+env:
+  SETUPTOOLS_SCM_PRETEND_VERSION: "0.0.0.dev${{ github.run_number }}"
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/src/sabr/alignment.py
+++ b/src/sabr/alignment.py
@@ -151,12 +151,12 @@ def load_references(
     with path.open("rb") as handle:
         data = np.load(handle, allow_pickle=True)["arr_0"].item()
     references = {}
-    for chain_type in constants.CHAIN_TYPES:
-        embeddings = np.asarray(data[chain_type]["array"])
+    for chain_type, reference in data.items():
+        embeddings = np.asarray(reference["array"])
         embeddings.flags.writeable = False
         references[chain_type] = (
             embeddings,
-            tuple(int(position) for position in data[chain_type]["idxs"]),
+            tuple(int(position) for position in reference["idxs"]),
         )
 
     if scfv:

--- a/src/sabr/api.py
+++ b/src/sabr/api.py
@@ -4,7 +4,7 @@ import logging
 from dataclasses import dataclass
 
 from sabr import constants
-from sabr.alignment import align
+from sabr.alignment import align, load_references
 from sabr.model import encode
 from sabr.numbering import number_alignment
 from sabr.structure import apply_numbering, extract_chain
@@ -19,12 +19,21 @@ def _normalize_choice(value: str, name: str, choices: tuple[str, ...]) -> str:
     return value.lower()
 
 
-def _normalize_chain_type(chain_type: str) -> str:
+def _normalize_chain_type(
+    chain_type: str,
+    noise_level: float,
+    mode: str,
+) -> str:
     if not isinstance(chain_type, str):
-        raise ValueError("chain_type must be 'auto', 'H', 'K', or 'L'.")
+        raise ValueError("chain_type must be a reference type or 'auto'.")
     normalized = "auto" if chain_type.lower() == "auto" else chain_type.upper()
-    if normalized not in ("auto", *constants.CHAIN_TYPES):
-        raise ValueError("chain_type must be 'auto', 'H', 'K', or 'L'.")
+    if normalized == "auto":
+        return normalized
+
+    reference_types = tuple(load_references(noise_level, mode))
+    if normalized not in reference_types:
+        choices = ", ".join(("auto", *reference_types))
+        raise ValueError(f"chain_type must be one of {choices}.")
     return normalized
 
 
@@ -49,24 +58,31 @@ def _normalize_noise_level(noise_level: float) -> float:
 def _validate_residue_range(
     residue_range: tuple[int, int] | None,
 ) -> None:
+    """Validate inclusive structure residue-number bounds.
+
+    The bounds are compared with BioPython ``residue.id[1]`` or Gemmi
+    ``residue.seqid.num``. They are residue numbers from the input structure,
+    not zero-based sequence or array indices, and need not begin at one or be
+    contiguous. Every insertion-code variant sharing a selected residue number
+    is included.
+    """
     if residue_range is None:
         return
-    if (
-        not isinstance(residue_range, tuple)
-        or len(residue_range) != 2
-        or not all(
-            isinstance(value, int) and not isinstance(value, bool)
-            for value in residue_range
-        )
+    error = "residue_range must be an inclusive (start, end) tuple."
+    if not isinstance(residue_range, tuple):
+        raise ValueError(error)
+    if len(residue_range) != 2:
+        raise ValueError(error)
+    if not all(
+        isinstance(value, int) and not isinstance(value, bool)
+        for value in residue_range
     ):
-        raise ValueError(
-            "residue_range must be an inclusive (start, end) tuple."
-        )
+        raise ValueError(error)
     if residue_range[0] > residue_range[1]:
         raise ValueError("residue_range start must not exceed its end.")
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(slots=True)
 class _RenumberOptions:
     """Validated and normalized arguments for one renumbering operation."""
 
@@ -78,21 +94,15 @@ class _RenumberOptions:
     scfv: bool
 
     def __post_init__(self) -> None:
-        object.__setattr__(
-            self,
-            "scheme",
-            _normalize_choice(
-                self.scheme, "scheme", constants.NUMBERING_SCHEMES
-            ),
+        self.scheme = _normalize_choice(
+            self.scheme, "scheme", constants.NUMBERING_SCHEMES
         )
-        object.__setattr__(
-            self, "chain_type", _normalize_chain_type(self.chain_type)
-        )
-        object.__setattr__(
-            self, "noise_level", _normalize_noise_level(self.noise_level)
-        )
-        object.__setattr__(
-            self, "mode", _normalize_choice(self.mode, "mode", constants.MODES)
+        self.noise_level = _normalize_noise_level(self.noise_level)
+        self.mode = _normalize_choice(self.mode, "mode", constants.MODES)
+        self.chain_type = _normalize_chain_type(
+            self.chain_type,
+            self.noise_level,
+            self.mode,
         )
         _validate_residue_range(self.residue_range)
         if not isinstance(self.scfv, bool):

--- a/src/sabr/api.py
+++ b/src/sabr/api.py
@@ -1,6 +1,7 @@
 """The public, in-memory SAbR API."""
 
 import logging
+from dataclasses import dataclass
 
 from sabr import constants
 from sabr.alignment import align
@@ -11,28 +12,23 @@ from sabr.structure import apply_numbering, extract_chain
 LOGGER = logging.getLogger(__name__)
 
 
-def _validate_options(
-    scheme: str,
-    chain_type: str,
-    noise_level: float,
-    residue_range: tuple | None,
-    mode: str,
-    scfv: bool,
-) -> tuple:
-    if (
-        not isinstance(scheme, str)
-        or scheme.lower() not in constants.NUMBERING_SCHEMES
-    ):
-        raise ValueError(
-            f"scheme must be one of {', '.join(constants.NUMBERING_SCHEMES)}."
-        )
+def _normalize_choice(value: str, name: str, choices: tuple[str, ...]) -> str:
+    """Normalize a case-insensitive string constrained to known choices."""
+    if not isinstance(value, str) or value.lower() not in choices:
+        raise ValueError(f"{name} must be one of {', '.join(choices)}.")
+    return value.lower()
+
+
+def _normalize_chain_type(chain_type: str) -> str:
     if not isinstance(chain_type, str):
         raise ValueError("chain_type must be 'auto', 'H', 'K', or 'L'.")
-    normalized_chain_type = (
-        "auto" if chain_type.lower() == "auto" else chain_type.upper()
-    )
-    if normalized_chain_type not in ("auto", *constants.CHAIN_TYPES):
+    normalized = "auto" if chain_type.lower() == "auto" else chain_type.upper()
+    if normalized not in ("auto", *constants.CHAIN_TYPES):
         raise ValueError("chain_type must be 'auto', 'H', 'K', or 'L'.")
+    return normalized
+
+
+def _normalize_noise_level(noise_level: float) -> float:
     if isinstance(noise_level, bool):
         raise ValueError(
             f"noise_level must be one of {constants.NOISE_LEVELS}."
@@ -47,33 +43,62 @@ def _validate_options(
         raise ValueError(
             f"noise_level must be one of {constants.NOISE_LEVELS}."
         )
-    if residue_range is not None:
-        if (
-            not isinstance(residue_range, tuple)
-            or len(residue_range) != 2
-            or not all(
-                isinstance(value, int) and not isinstance(value, bool)
-                for value in residue_range
-            )
-        ):
-            raise ValueError(
-                "residue_range must be an inclusive (start, end) tuple."
-            )
-        if residue_range[0] > residue_range[1]:
-            raise ValueError("residue_range start must not exceed its end.")
-    if not isinstance(mode, str) or mode.lower() not in constants.MODES:
-        raise ValueError(f"mode must be one of {', '.join(constants.MODES)}.")
-    if not isinstance(scfv, bool):
-        raise ValueError("scfv must be a boolean.")
-    if scfv and normalized_chain_type != "auto":
-        raise ValueError("scfv requires chain_type='auto'.")
-    return (
-        scheme.lower(),
-        normalized_chain_type,
-        normalized_noise,
-        mode.lower(),
-        scfv,
-    )
+    return normalized_noise
+
+
+def _validate_residue_range(
+    residue_range: tuple[int, int] | None,
+) -> None:
+    if residue_range is None:
+        return
+    if (
+        not isinstance(residue_range, tuple)
+        or len(residue_range) != 2
+        or not all(
+            isinstance(value, int) and not isinstance(value, bool)
+            for value in residue_range
+        )
+    ):
+        raise ValueError(
+            "residue_range must be an inclusive (start, end) tuple."
+        )
+    if residue_range[0] > residue_range[1]:
+        raise ValueError("residue_range start must not exceed its end.")
+
+
+@dataclass(frozen=True, slots=True)
+class _RenumberOptions:
+    """Validated and normalized arguments for one renumbering operation."""
+
+    scheme: str
+    chain_type: str
+    noise_level: float
+    residue_range: tuple[int, int] | None
+    mode: str
+    scfv: bool
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "scheme",
+            _normalize_choice(
+                self.scheme, "scheme", constants.NUMBERING_SCHEMES
+            ),
+        )
+        object.__setattr__(
+            self, "chain_type", _normalize_chain_type(self.chain_type)
+        )
+        object.__setattr__(
+            self, "noise_level", _normalize_noise_level(self.noise_level)
+        )
+        object.__setattr__(
+            self, "mode", _normalize_choice(self.mode, "mode", constants.MODES)
+        )
+        _validate_residue_range(self.residue_range)
+        if not isinstance(self.scfv, bool):
+            raise ValueError("scfv must be a boolean.")
+        if self.scfv and self.chain_type != "auto":
+            raise ValueError("scfv requires chain_type='auto'.")
 
 
 def renumber_structure(
@@ -92,18 +117,23 @@ def renumber_structure(
     penalties as one scientifically consistent parameter set. ``scfv=True``
     adds the four supported two-domain composite references.
     """
-    scheme, chain_type, noise_level, mode, scfv = _validate_options(
-        scheme, chain_type, noise_level, residue_range, mode, scfv
+    options = _RenumberOptions(
+        scheme=scheme,
+        chain_type=chain_type,
+        noise_level=noise_level,
+        residue_range=residue_range,
+        mode=mode,
+        scfv=scfv,
     )
-    data = extract_chain(structure, chain, residue_range)
-    embeddings = encode(data.coords, mode)
+    data = extract_chain(structure, chain, options.residue_range)
+    embeddings = encode(data.coords, options.mode)
     imgt_alignment, selected_type, score = align(
         embeddings,
         data.gap_indices,
-        chain_type,
-        noise_level,
-        mode=mode,
-        scfv=scfv,
+        options.chain_type,
+        options.noise_level,
+        mode=options.mode,
+        scfv=options.scfv,
     )
     LOGGER.info(
         "Selected %s reference with alignment score %.4f.",
@@ -113,7 +143,7 @@ def renumber_structure(
     numbered = number_alignment(
         imgt_alignment,
         data.sequence,
-        scheme,
+        options.scheme,
         selected_type,
     )
     return apply_numbering(structure, chain, data, numbered)

--- a/src/sabr/numbering.py
+++ b/src/sabr/numbering.py
@@ -2,20 +2,36 @@
 
 import functools
 import logging
-from collections.abc import Mapping
 from importlib.resources import files
 
 import numpy as np
 
 from sabr import constants
-from sabr._anarci import schemes
+from sabr._anarci.schemes import alphabet as _anarci_insertion_codes
+from sabr._anarci.schemes import (
+    number_aho,
+    number_chothia_heavy,
+    number_chothia_light,
+    number_imgt,
+    number_kabat_heavy,
+    number_kabat_light,
+    number_martin_heavy,
+    number_martin_light,
+    number_wolfguy_heavy,
+    number_wolfguy_light,
+)
 
 LOGGER = logging.getLogger(__name__)
 
 
 @functools.cache
 def _load_missing_imgt_positions() -> dict[str, frozenset[int]]:
-    """Derive absent IMGT positions from the canonical reference metadata."""
+    """Derive absent IMGT positions from the canonical reference metadata.
+
+    The default numbering path uses a full 128-column alignment and never
+    needs this metadata. Keeping the asset read behind a cached function makes
+    reduced-reference support lazy without introducing a proxy mapping type.
+    """
     path = files("sabr.assets") / "embeddings_noise_0.0.npz"
     with (
         path.open("rb") as handle,
@@ -32,30 +48,32 @@ def _load_missing_imgt_positions() -> dict[str, frozenset[int]]:
     }
 
 
-class _MissingIMGTPositions(Mapping[str, frozenset[int]]):
-    """Read-only, lazily loaded missing-position metadata."""
-
-    def __getitem__(self, chain_type: str) -> frozenset[int]:
-        return _load_missing_imgt_positions()[chain_type]
-
-    def __iter__(self):
-        return iter(_load_missing_imgt_positions())
-
-    def __len__(self) -> int:
-        return len(_load_missing_imgt_positions())
-
-
-MISSING_IMGT_POSITIONS = _MissingIMGTPositions()
+# These are ANARCI's T-cell receptor chain labels. The public SAbR pipeline
+# supports antibody references H/K/L; A/B/G/D are accepted only by the
+# low-level numbering conversion for the experimental TCR workflow documented
+# in the README. Of the vendored ANARCI schemes, only IMGT and AHo define TCR
+# behavior (and AHo needs the actual TCR chain label).
 _TCR_CHAIN_TYPES = frozenset({"A", "B", "G", "D"})
 
 
 def _validate_reference_positions(
     matrix: np.ndarray,
-    ref_positions: tuple[int, ...] | None,
-) -> tuple[int, ...] | None:
-    """Validate and normalize reduced-reference IMGT positions."""
-    if ref_positions is None:
-        return None
+    ref_positions: tuple[int, ...],
+) -> None:
+    """Validate the IMGT-position label for each reference column.
+
+    A normal SAbR alignment has 128 reference columns, so column ``i`` is
+    unambiguously IMGT position ``i + 1``. Some low-level callers instead
+    align against a reduced reference that omits positions. In that case,
+    ``ref_positions[i]`` supplies the absolute IMGT position represented by
+    column ``i``.
+
+    There must be exactly one label per matrix column. Labels are immutable
+    integer metadata, are confined to one 1--128 IMGT domain, and must be
+    strictly increasing so that walking left-to-right through the matrix also
+    walks forward through IMGT numbering. ``bool`` is rejected explicitly
+    because it is an ``int`` subclass in Python.
+    """
     if not isinstance(ref_positions, tuple):
         raise ValueError("ref_positions must be a tuple.")
     if len(ref_positions) != matrix.shape[1]:
@@ -76,33 +94,59 @@ def _validate_reference_positions(
         right <= left for left, right in zip(ref_positions, ref_positions[1:])
     ):
         raise ValueError("ref_positions must be strictly increasing.")
-    return ref_positions
 
 
 def alignment_to_states(
     matrix: np.ndarray,
     *,
     ref_positions: tuple[int, ...] | None = None,
-) -> tuple:
-    """Return ANARCI-compatible states and the first aligned query row."""
+) -> tuple[list[tuple[tuple[int, str], int | None]], int, int]:
+    """Translate a query/reference alignment into ANARCI state records.
+
+    ``matrix`` uses query residues as rows and reference positions as columns;
+    a value of one assigns that query row to that reference column. Full
+    references derive the IMGT position as ``column + 1``. Reduced references
+    must provide the absolute position of each column through
+    ``ref_positions``.
+
+    ANARCI consumes records shaped like ``((position, state), sequence_index)``
+    where ``state`` is ``"m"`` for a match, ``"d"`` for a reference deletion,
+    or ``"i"`` for a query insertion. The sequence index is expressed against
+    a left-padded sequence: padding makes the first aligned query residue land
+    at the zero-based index corresponding to its absolute IMGT position.
+
+    Returns:
+        A tuple containing the ordered ANARCI states, the number of leading
+        sequence-padding characters required, and the original row of the
+        first aligned query residue.
+
+    Raises:
+        ValueError: If the matrix is not two-dimensional, contains no aligned
+            residues, or has invalid reduced-reference position metadata.
+    """
     if matrix.ndim != 2:
         raise ValueError("Alignment matrix must be two-dimensional.")
     if ref_positions is not None:
-        ref_positions = _validate_reference_positions(matrix, ref_positions)
+        _validate_reference_positions(matrix, ref_positions)
+
+    # Transposing makes every path item ``(reference column, query row)``.
+    # Sorting in that order lets us emit ANARCI states by IMGT position.
     path = sorted(np.argwhere(matrix.T == 1).tolist())
     if not path:
         raise ValueError("Alignment matrix contains no aligned residues.")
 
     column_rows = {}
-    row_columns = {}
+    assigned_rows = set()
     for column, row in path:
         column_rows.setdefault(column, []).append(row)
-        row_columns[row] = column
+        assigned_rows.add(row)
 
     first_column, first_row = path[0]
-    last_column, last_row = path[-1]
-    orphan_rows = {
-        row for row in range(first_row, last_row + 1) if row not in row_columns
+    last_column, _ = path[-1]
+    aligned_columns = sorted(column_rows)
+    next_row_by_column = {
+        column: column_rows[next_column][0]
+        for column, next_column in zip(aligned_columns, aligned_columns[1:])
     }
     first_position = (
         ref_positions[first_column]
@@ -118,22 +162,23 @@ def alignment_to_states(
             ref_positions[column] if ref_positions is not None else column + 1
         )
         if column not in column_rows:
+            # No query row occupies this represented reference position.
             states.append(((imgt_position, "d"), None))
             continue
 
         rows = column_rows[column]
+        # The first assigned row matches the reference position. Any further
+        # rows assigned to the same column are insertions after that position.
         states.append(((imgt_position, "m"), rows[0] + offset))
         for row in rows[1:]:
             states.append(((imgt_position, "i"), row + offset))
 
-        next_row = None
-        for later_column in range(column + 1, last_column + 1):
-            if later_column in column_rows:
-                next_row = column_rows[later_column][0]
-                break
+        # Query rows with no matrix assignment, but bracketed by two assigned
+        # columns, are also insertions after the earlier IMGT position.
+        next_row = next_row_by_column.get(column)
         if next_row is not None:
             for row in range(rows[-1] + 1, next_row):
-                if row in orphan_rows:
+                if row not in assigned_rows:
                     states.append(((imgt_position, "i"), row + offset))
 
     return states, imgt_start, first_row
@@ -141,11 +186,11 @@ def alignment_to_states(
 
 def _insert_missing_deletions(states: list, ref_type: str) -> list:
     """Add absent reference positions as idempotent deletion states."""
-    if ref_type not in MISSING_IMGT_POSITIONS:
+    if ref_type not in constants.CHAIN_TYPES:
         raise ValueError("ref_type must be 'H', 'K', or 'L'.")
 
     represented = {state[0][0] for state in states}
-    missing = MISSING_IMGT_POSITIONS[ref_type].difference(represented)
+    missing = _load_missing_imgt_positions()[ref_type].difference(represented)
     if not missing:
         return states
 
@@ -163,33 +208,20 @@ def _insert_missing_deletions(states: list, ref_type: str) -> list:
 
 
 def _apply_scheme(states: list, sequence: str, scheme: str, chain_type: str):
+    """Dispatch to a vendored ANARCI numberer through one call signature."""
     if chain_type in _TCR_CHAIN_TYPES and scheme not in ("imgt", "aho"):
         raise ValueError("TCR chain types support only IMGT or AHo numbering.")
-    if scheme == "imgt":
-        return schemes.number_imgt(states, sequence)
-    if scheme == "aho":
-        return schemes.number_aho(states, sequence, chain_type)
 
     heavy = chain_type == "H"
     functions = {
-        "chothia": (
-            schemes.number_chothia_heavy
-            if heavy
-            else schemes.number_chothia_light
+        "imgt": number_imgt,
+        "aho": lambda current_states, current_sequence: number_aho(
+            current_states, current_sequence, chain_type
         ),
-        "kabat": (
-            schemes.number_kabat_heavy if heavy else schemes.number_kabat_light
-        ),
-        "martin": (
-            schemes.number_martin_heavy
-            if heavy
-            else schemes.number_martin_light
-        ),
-        "wolfguy": (
-            schemes.number_wolfguy_heavy
-            if heavy
-            else schemes.number_wolfguy_light
-        ),
+        "chothia": (number_chothia_heavy if heavy else number_chothia_light),
+        "kabat": (number_kabat_heavy if heavy else number_kabat_light),
+        "martin": (number_martin_heavy if heavy else number_martin_light),
+        "wolfguy": (number_wolfguy_heavy if heavy else number_wolfguy_light),
     }
     return functions[scheme](states, sequence)
 
@@ -209,13 +241,14 @@ def _number_domain_alignment(
         ref_positions=ref_positions,
     )
     if ref_type is not None:
-        if ref_type not in MISSING_IMGT_POSITIONS:
+        if ref_type not in constants.CHAIN_TYPES:
             raise ValueError("ref_type must be 'H', 'K', or 'L'.")
         if ref_positions is not None:
             missing_positions = frozenset(
                 range(1, constants.IMGT_MAX_POSITION + 1)
             ).difference(ref_positions)
-            if missing_positions != MISSING_IMGT_POSITIONS[ref_type]:
+            reference_missing = _load_missing_imgt_positions()[ref_type]
+            if missing_positions != reference_missing:
                 raise ValueError(
                     f"ref_positions do not match the {ref_type} reference."
                 )
@@ -273,47 +306,52 @@ def number_alignment(
     single-domain references. Normal 128-column antibody and 256-column scFv
     alignments leave them unset.
     """
-    if ":" not in chain_type:
-        return _number_domain_alignment(
-            alignment,
-            sequence,
-            scheme,
-            chain_type,
-            ref_type=ref_type,
-            ref_positions=ref_positions,
-        )
-
-    if ref_type is not None or ref_positions is not None:
+    chain_types = chain_type.split(":")
+    is_composite = len(chain_types) > 1
+    if is_composite and (ref_type is not None or ref_positions is not None):
         raise ValueError(
             "Reference metadata is supported only for single-domain "
             "alignments."
         )
 
-    chain_types = chain_type.split(":")
-    expected_columns = len(chain_types) * constants.IMGT_MAX_POSITION
-    if alignment.ndim != 2 or alignment.shape[1] != expected_columns:
-        raise ValueError(
-            f"scFv alignment must have {expected_columns} columns."
-        )
+    if is_composite:
+        expected_columns = len(chain_types) * constants.IMGT_MAX_POSITION
+        if alignment.ndim != 2 or alignment.shape[1] != expected_columns:
+            raise ValueError(
+                f"scFv alignment must have {expected_columns} columns."
+            )
 
     domains = []
     for domain_index, domain_type in enumerate(chain_types):
-        start = domain_index * constants.IMGT_MAX_POSITION
-        end = start + constants.IMGT_MAX_POSITION
+        if is_composite:
+            start = domain_index * constants.IMGT_MAX_POSITION
+            end = start + constants.IMGT_MAX_POSITION
+            domain_alignment = alignment[:, start:end]
+        else:
+            domain_alignment = alignment
         records = _number_domain_alignment(
-            alignment[:, start:end], sequence, scheme, domain_type
+            domain_alignment,
+            sequence,
+            scheme,
+            domain_type,
+            ref_type=ref_type,
+            ref_positions=ref_positions,
         )
         if domain_index:
+            number_offset = domain_index * constants.IMGT_MAX_POSITION
             records = [
                 (
                     query_row,
-                    number + constants.IMGT_MAX_POSITION,
+                    number + number_offset,
                     insertion_code,
                     amino_acid,
                 )
                 for query_row, number, insertion_code, amino_acid in records
             ]
         domains.append(records)
+
+    if not is_composite:
+        return domains[0]
 
     first_domain, second_domain = domains
     linker_start = first_domain[-1][0] + 1
@@ -325,7 +363,7 @@ def number_alignment(
     linker_number = first_domain[-1][1]
     available_codes = (
         code
-        for code in schemes.alphabet
+        for code in _anarci_insertion_codes
         if code.strip() and (linker_number, code) not in used_ids
     )
     linker = [

--- a/src/sabr/numbering.py
+++ b/src/sabr/numbering.py
@@ -42,9 +42,9 @@ def _load_missing_imgt_positions() -> dict[str, frozenset[int]]:
     all_positions = frozenset(range(1, constants.IMGT_MAX_POSITION + 1))
     return {
         chain_type: all_positions.difference(
-            int(position) for position in data[chain_type]["idxs"]
+            int(position) for position in reference["idxs"]
         )
-        for chain_type in constants.CHAIN_TYPES
+        for chain_type, reference in data.items()
     }
 
 
@@ -186,11 +186,13 @@ def alignment_to_states(
 
 def _insert_missing_deletions(states: list, ref_type: str) -> list:
     """Add absent reference positions as idempotent deletion states."""
-    if ref_type not in constants.CHAIN_TYPES:
-        raise ValueError("ref_type must be 'H', 'K', or 'L'.")
+    missing_by_type = _load_missing_imgt_positions()
+    if ref_type not in missing_by_type:
+        choices = ", ".join(missing_by_type)
+        raise ValueError(f"ref_type must be one of {choices}.")
 
     represented = {state[0][0] for state in states}
-    missing = _load_missing_imgt_positions()[ref_type].difference(represented)
+    missing = missing_by_type[ref_type].difference(represented)
     if not missing:
         return states
 
@@ -241,13 +243,15 @@ def _number_domain_alignment(
         ref_positions=ref_positions,
     )
     if ref_type is not None:
-        if ref_type not in constants.CHAIN_TYPES:
-            raise ValueError("ref_type must be 'H', 'K', or 'L'.")
+        missing_by_type = _load_missing_imgt_positions()
+        if ref_type not in missing_by_type:
+            choices = ", ".join(missing_by_type)
+            raise ValueError(f"ref_type must be one of {choices}.")
         if ref_positions is not None:
             missing_positions = frozenset(
                 range(1, constants.IMGT_MAX_POSITION + 1)
             ).difference(ref_positions)
-            reference_missing = _load_missing_imgt_positions()[ref_type]
+            reference_missing = missing_by_type[ref_type]
             if missing_positions != reference_missing:
                 raise ValueError(
                     f"ref_positions do not match the {ref_type} reference."

--- a/src/sabr/structure.py
+++ b/src/sabr/structure.py
@@ -3,6 +3,7 @@
 import copy
 import functools
 import json
+from dataclasses import dataclass
 from importlib.resources import files
 
 import gemmi
@@ -13,22 +14,15 @@ from Bio.PDB.Structure import Structure as BioStructure
 from sabr import constants
 
 
+@dataclass(frozen=True, slots=True)
 class _ChainData:
     """Private, normalized view of the selected polymer residues."""
 
-    def __init__(
-        self,
-        coords: np.ndarray,
-        sequence: str,
-        residue_ids: list,
-        residue_indices: list,
-        gap_indices: frozenset,
-    ):
-        self.coords = coords
-        self.sequence = sequence
-        self.residue_ids = residue_ids
-        self.residue_indices = residue_indices
-        self.gap_indices = gap_indices
+    coords: np.ndarray
+    sequence: str
+    residue_ids: tuple[tuple[int, str], ...]
+    residue_indices: tuple[int, ...]
+    gap_indices: frozenset[int]
 
 
 def _compute_cb(n_coord: np.ndarray, ca_coord: np.ndarray, c_coord: np.ndarray):
@@ -189,7 +183,18 @@ def _detect_gaps(coords: np.ndarray) -> frozenset:
 def extract_chain(
     structure, chain: str, residue_range: tuple | None
 ) -> _ChainData:
-    """Normalize the selected polymer residues without modifying the input."""
+    """Normalize selected polymer residues without modifying the structure.
+
+    Besides producing model coordinates and a one-letter sequence, extraction
+    retains each residue's index in the original chain so numbering can later
+    be applied to a same-type clone containing all original hetero residues.
+
+    Unknown HETATM residues need a deliberate second pass. Most are ligands or
+    solvent and should be preserved but ignored; an unknown residue with a
+    complete backbone that is peptide-bonded to a recognized amino acid is
+    instead unsupported polymer chemistry and must fail explicitly. Its
+    neighbors are not known until the first pass has classified the chain.
+    """
     target = _find_chain(structure, chain)
     is_biopython = isinstance(structure, BioStructure)
     coords = []
@@ -200,6 +205,8 @@ def extract_chain(
     unknown_hetero = []
     polymer_ids = set()
 
+    # First pass: adapt BioPython/Gemmi metadata and separate recognized
+    # polymer residues from unknown HETATM records that may merely be ligands.
     for index, residue in enumerate(target):
         if is_biopython:
             number = residue.id[1]
@@ -272,6 +279,9 @@ def extract_chain(
             )
         )
 
+    # A backbone-shaped HETATM is safe to ignore only when it is not connected
+    # to the recognized polymer on either side. This catches unsupported
+    # peptide residues without rejecting unrelated ligands or solvent.
     for index, residue_name, number, insertion_code, backbone in unknown_hetero:
         previous = next(
             (entry for entry in reversed(normalized) if entry[0] < index),
@@ -303,6 +313,9 @@ def extract_chain(
             "residue_range to select one antibody domain."
         )
 
+    # Second pass: build the dense model inputs after residue classification is
+    # complete. Modified residues use their canonical parent only for sequence
+    # generation; the returned numbering is applied to unchanged source atoms.
     for index, number, insertion_code, parent_name, backbone in normalized:
         n_coord, ca_coord, c_coord = backbone
         residue_coords = np.stack(
@@ -332,8 +345,8 @@ def extract_chain(
     return _ChainData(
         stacked_coords,
         "".join(sequence),
-        residue_ids,
-        residue_indices,
+        tuple(residue_ids),
+        tuple(residue_indices),
         _detect_gaps(stacked_coords),
     )
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -176,6 +176,33 @@ def test_softalign_mode_is_forwarded_to_encoder_and_alignment(monkeypatch):
     }
 
 
+def test_chain_type_choices_come_from_reference_asset(monkeypatch):
+    monkeypatch.setattr(
+        api,
+        "load_references",
+        lambda noise_level, mode: {"X": (None, None)},
+    )
+    options = api._RenumberOptions(
+        scheme="imgt",
+        chain_type="x",
+        noise_level=0.0,
+        residue_range=None,
+        mode="sabr",
+        scfv=False,
+    )
+    assert options.chain_type == "X"
+
+    with pytest.raises(ValueError, match="auto, X"):
+        api._RenumberOptions(
+            scheme="imgt",
+            chain_type="H",
+            noise_level=0.0,
+            residue_range=None,
+            mode="sabr",
+            scfv=False,
+        )
+
+
 def test_missing_backbone_is_reported_with_the_residue():
     structure = PDBParser(QUIET=True).get_structure(
         "missing", DATA / "test_no_backbone.pdb"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -132,7 +132,7 @@ def test_numeric_residue_range_includes_insertion_codes():
         "insertions", DATA / "test_insertion_codes.pdb"
     )
     data = extract_chain(structure, "A", (52, 52))
-    assert data.residue_ids == [(52, ""), (52, "A"), (52, "B")]
+    assert data.residue_ids == ((52, ""), (52, "A"), (52, "B"))
 
 
 def test_range_that_would_collide_with_unchanged_ids_is_rejected(

--- a/tests/test_hygiene.py
+++ b/tests/test_hygiene.py
@@ -4,24 +4,27 @@ from pathlib import Path
 SOURCE = Path(__file__).parents[1] / "src" / "sabr"
 
 
-def _walk_with_scope(node, inside_function=False):
+def _walk_with_scope(node, inside_function=False, inside_class=False):
     for child in ast.iter_child_nodes(node):
-        child_inside = inside_function or isinstance(
+        child_inside_function = inside_function or isinstance(
             child, (ast.FunctionDef, ast.AsyncFunctionDef)
         )
-        yield child, inside_function
-        yield from _walk_with_scope(child, child_inside)
+        child_inside_class = inside_class or isinstance(child, ast.ClassDef)
+        yield child, inside_function, inside_class
+        yield from _walk_with_scope(
+            child, child_inside_function, child_inside_class
+        )
 
 
-def test_no_lazy_imports_or_variable_annotations():
+def test_no_lazy_imports_or_module_variable_annotations():
     for path in SOURCE.glob("*.py"):
         tree = ast.parse(path.read_text(), filename=str(path))
-        for node, inside_function in _walk_with_scope(tree):
+        for node, inside_function, inside_class in _walk_with_scope(tree):
             if isinstance(node, (ast.Import, ast.ImportFrom)):
                 assert (
                     not inside_function
                 ), f"Lazy import in {path}: {node.lineno}"
             if isinstance(node, ast.AnnAssign):
                 assert (
-                    inside_function
-                ), f"Variable/class annotation in {path}: {node.lineno}"
+                    inside_function or inside_class
+                ), f"Module variable annotation in {path}: {node.lineno}"

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -17,7 +17,7 @@ from sabr.alignment import (
     load_references,
 )
 from sabr.model import encode, load_parameters
-from sabr.numbering import MISSING_IMGT_POSITIONS
+from sabr.numbering import _load_missing_imgt_positions
 from sabr.structure import extract_chain
 
 DATA = Path(__file__).parent / "data"
@@ -112,12 +112,13 @@ def test_missing_imgt_metadata_matches_every_reference_asset():
         load_references(level) for level in constants.NOISE_LEVELS
     ]
     reference_sets.append(load_references(0.0, "softalign"))
+    missing_imgt_positions = _load_missing_imgt_positions()
 
     all_positions = frozenset(range(1, constants.IMGT_MAX_POSITION + 1))
     for references in reference_sets:
         for chain_type, (_, positions) in references.items():
             assert all_positions.difference(positions) == (
-                MISSING_IMGT_POSITIONS[chain_type]
+                missing_imgt_positions[chain_type]
             )
 
 

--- a/tests/test_numbering.py
+++ b/tests/test_numbering.py
@@ -226,23 +226,6 @@ def test_low_level_tcr_aho_uses_the_actual_chain_type(monkeypatch, chain_type):
     ) == [(0, 1, "", "A")]
 
 
-def test_low_level_tcr_imgt_numbering_is_available(monkeypatch):
-    alignment = np.zeros((1, constants.IMGT_MAX_POSITION), dtype=int)
-    alignment[0, 0] = 1
-    monkeypatch.setattr(
-        numbering,
-        "number_imgt",
-        lambda states, sequence: ([((1, ""), "A")], 0, 0),
-    )
-    assert number_alignment(
-        alignment,
-        "A",
-        "imgt",
-        "A",
-        ref_type="K",
-    ) == [(0, 1, "", "A")]
-
-
 @pytest.mark.parametrize("chain_type", ("A", "B", "G", "D"))
 @pytest.mark.parametrize("scheme", ("chothia", "kabat", "martin", "wolfguy"))
 def test_tcr_chain_types_reject_antibody_only_schemes(chain_type, scheme):
@@ -278,10 +261,7 @@ def test_reference_metadata_rejects_invalid_or_ambiguous_combinations():
         )
 
 
-@pytest.mark.parametrize("chain_type", constants.CHAIN_TYPES)
-def test_default_single_domain_numbering_skips_reference_completion(
-    monkeypatch, chain_type
-):
+def test_default_numbering_skips_reduced_reference_completion(monkeypatch):
     monkeypatch.setattr(
         numbering,
         "_load_missing_imgt_positions",
@@ -301,7 +281,7 @@ def test_default_single_domain_numbering_skips_reference_completion(
             1,
         ),
     )
-    assert number_alignment(np.eye(2, dtype=int), "AC", "imgt", chain_type) == [
+    assert number_alignment(np.eye(2, dtype=int), "AC", "imgt", "H") == [
         (0, 1, "", "A"),
         (1, 2, "", "C"),
     ]
@@ -374,16 +354,6 @@ def test_scfv_numbering_offsets_second_domain_and_numbers_linker(monkeypatch):
             return [((1, ""), "A"), ((2, ""), "C")], 0, 1
         return [((1, ""), "E"), ((2, ""), "F")], 0, 1
 
-    monkeypatch.setattr(
-        numbering,
-        "_load_missing_imgt_positions",
-        lambda: pytest.fail("scFv path loaded reference metadata"),
-    )
-    monkeypatch.setattr(
-        numbering,
-        "_insert_missing_deletions",
-        lambda *args: pytest.fail("scFv path completed reference states"),
-    )
     monkeypatch.setattr(numbering, "_apply_scheme", fake_scheme)
     assert number_alignment(alignment, "ACDEF", "imgt", "H:K") == [
         (0, 1, "", "A"),

--- a/tests/test_numbering.py
+++ b/tests/test_numbering.py
@@ -75,7 +75,7 @@ def test_reduced_reference_positions_control_states_and_padding(monkeypatch):
 
 
 def test_k_reduced_reference_expands_to_every_imgt_state(monkeypatch):
-    missing = numbering.MISSING_IMGT_POSITIONS["K"]
+    missing = numbering._load_missing_imgt_positions()["K"]
     ref_positions = tuple(
         position
         for position in range(1, constants.IMGT_MAX_POSITION + 1)
@@ -124,7 +124,7 @@ def test_k_reduced_reference_expands_to_every_imgt_state(monkeypatch):
 def test_reduced_k_reference_runs_real_tcr_numbering(
     chain_type, scheme, last_number
 ):
-    missing = numbering.MISSING_IMGT_POSITIONS["K"]
+    missing = numbering._load_missing_imgt_positions()["K"]
     ref_positions = tuple(
         position
         for position in range(1, constants.IMGT_MAX_POSITION + 1)
@@ -156,15 +156,12 @@ def test_missing_deletion_insertion_is_idempotent_and_preserves_insertions():
     assert [state for state in completed if state[0][0] == 9] == states[:2]
     assert ((10, "d"), None) in completed
 
+    missing = numbering._load_missing_imgt_positions()["K"]
     expanded = [
         (
             (
                 position,
-                (
-                    "d"
-                    if position in numbering.MISSING_IMGT_POSITIONS["K"]
-                    else "m"
-                ),
+                ("d" if position in missing else "m"),
             ),
             None,
         )
@@ -201,10 +198,10 @@ def test_low_level_tcr_aho_uses_the_actual_chain_type(monkeypatch, chain_type):
             position
             for ((position, state_type), _) in states
             if state_type == "d"
-        } == numbering.MISSING_IMGT_POSITIONS["K"]
+        } == numbering._load_missing_imgt_positions()["K"]
         return [((1, ""), "A")], 0, 0
 
-    monkeypatch.setattr(numbering.schemes, "number_aho", fake_aho)
+    monkeypatch.setattr(numbering, "number_aho", fake_aho)
     assert number_alignment(
         alignment,
         "A",
@@ -218,7 +215,7 @@ def test_low_level_tcr_imgt_numbering_is_available(monkeypatch):
     alignment = np.zeros((1, constants.IMGT_MAX_POSITION), dtype=int)
     alignment[0, 0] = 1
     monkeypatch.setattr(
-        numbering.schemes,
+        numbering,
         "number_imgt",
         lambda states, sequence: ([((1, ""), "A")], 0, 0),
     )

--- a/tests/test_numbering.py
+++ b/tests/test_numbering.py
@@ -170,6 +170,21 @@ def test_missing_deletion_insertion_is_idempotent_and_preserves_insertions():
     assert numbering._insert_missing_deletions(expanded, "K") is expanded
 
 
+def test_reference_type_choices_come_from_reference_asset(monkeypatch):
+    monkeypatch.setattr(
+        numbering,
+        "_load_missing_imgt_positions",
+        lambda: {"X": frozenset({2})},
+    )
+    states = [((1, "m"), 0)]
+    assert numbering._insert_missing_deletions(states, "X") == [
+        ((1, "m"), 0),
+        ((2, "d"), None),
+    ]
+    with pytest.raises(ValueError, match="one of X"):
+        numbering._insert_missing_deletions(states, "H")
+
+
 @pytest.mark.parametrize(
     ("ref_positions", "message"),
     [


### PR DESCRIPTION
## Summary

- replace the one-instance missing-IMGT-position proxy with direct use of a cached metadata loader
- explicitly import vendored ANARCI numbering functions and dispatch every scheme through one call path
- document reduced-reference validation and alignment-to-state conversion
- process single-domain and scFv alignments through one domain loop
- replace the monolithic API option validator with focused normalizers and a frozen options dataclass
- convert `_ChainData` to a frozen, slotted dataclass and document the two-phase chain extraction logic

## Why

The previous implementation spread several small concerns across proxy classes, special-case scheme branches, tuple-returning validation, and undocumented alignment conventions. This made the reduced-reference and structure-extraction paths harder to reason about than their behavior required.

The refactor keeps the same public API and scientific behavior while making the vendored ANARCI boundary, TCR limitations, alignment-state representation, and structure normalization invariants explicit.

## Impact

There are no intended user-facing behavior changes. Internal records are immutable, argument normalization is centralized in a validated value object, and tests now reference the cached metadata loader directly.

## Validation

- `JAX_PLATFORMS=cpu pytest --cov=sabr`: 148 passed, 96.57% coverage
- `pre-commit run --all-files`: Black, isort, and flake8 passed
