### PR TITLE
Automatically use mmCIF for extended insertion codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ sabr -i INPUT -c CHAIN -o OUTPUT
      [-m sabr|softalign]
      [--residue-range START END]
      [--scfv]
+     [--no-mmcif]
      [--overwrite] [-v]
 ```
 
@@ -55,9 +56,12 @@ already specifies both domain types, scFv mode requires automatic chain type.
 Composite references use the selected parameter mode, so `--scfv` can be
 combined with `--mode softalign`.
 
-Input and output may be PDB (`.pdb`) or mmCIF (`.cif` or `.mmcif`). Use mmCIF
-when chain names or ANARCI insertion codes exceed PDB's one-character fields.
-Writes are atomic, so a failed run does not leave a partial output.
+Input and output may be PDB (`.pdb`) or mmCIF (`.cif` or `.mmcif`). When a
+requested PDB output needs multi-character insertion codes, SAbR warns and
+automatically writes it to the corresponding `.cif` path instead. Pass
+`--no-mmcif` to forbid this conversion and fail. Other values that exceed PDB
+field limits still require an explicitly named mmCIF output. Writes are atomic,
+so a failed run does not leave a partial output.
 
 CLI conversion guarantees preservation of atomic structure content, not
 arbitrary non-atomic mmCIF categories. It warns for every mmCIF input. When

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,6 +55,7 @@ sabr -i INPUT -c CHAIN -o OUTPUT
      [-m sabr|softalign]
      [--residue-range START END]
      [--scfv]
+     [--no-mmcif]
      [--overwrite] [-v]
 ```
 
@@ -150,6 +151,11 @@ Use mmCIF when a structure has:
 - multi-character insertion codes;
 - residue numbers outside the PDB range `-999` through `9999`; or
 - more than 99,999 atoms.
+
+If a requested `.pdb` output needs multi-character insertion codes, the CLI
+warns and writes the result to the corresponding `.cif` path automatically.
+Pass `--no-mmcif` to forbid this fallback and report the PDB limitation as an
+error. Other PDB field limits do not trigger automatic conversion.
 
 Gemmi structure objects can represent only one-character insertion codes. For
 exceptionally long CDR insertions, use a BioPython structure and mmCIF output.

--- a/src/sabr/cli.py
+++ b/src/sabr/cli.py
@@ -53,14 +53,11 @@ def _validate_pdb_output(structure) -> None:
 
 def _has_extended_insertion_codes(structure) -> bool:
     return any(
-        len(residue.id[2].strip()) > 1
-        for residue in structure.get_residues()
+        len(residue.id[2].strip()) > 1 for residue in structure.get_residues()
     )
 
 
-def _resolve_output_path(
-    structure, path: Path, no_mmcif: bool = False
-) -> Path:
+def _resolve_output_path(structure, path: Path, no_mmcif: bool = False) -> Path:
     if (
         path.suffix.lower() == ".pdb"
         and not no_mmcif

--- a/src/sabr/cli.py
+++ b/src/sabr/cli.py
@@ -51,6 +51,25 @@ def _validate_pdb_output(structure) -> None:
                 )
 
 
+def _has_extended_insertion_codes(structure) -> bool:
+    return any(
+        len(residue.id[2].strip()) > 1
+        for residue in structure.get_residues()
+    )
+
+
+def _resolve_output_path(
+    structure, path: Path, no_mmcif: bool = False
+) -> Path:
+    if (
+        path.suffix.lower() == ".pdb"
+        and not no_mmcif
+        and _has_extended_insertion_codes(structure)
+    ):
+        return path.with_suffix(".cif")
+    return path
+
+
 def _write_structure(structure, path: Path) -> None:
     suffix = path.suffix.lower()
     if suffix == ".pdb":
@@ -122,6 +141,11 @@ def _write_structure(structure, path: Path) -> None:
     is_flag=True,
     help="Also try H:K, H:L, K:H, and L:H composite references.",
 )
+@click.option(
+    "--no-mmcif",
+    is_flag=True,
+    help="Forbid automatic mmCIF output for extended insertion codes.",
+)
 @click.option("--overwrite", is_flag=True)
 @click.option("-v", "--verbose", is_flag=True)
 def main(
@@ -134,6 +158,7 @@ def main(
     mode: str,
     residue_range: tuple | None,
     scfv: bool,
+    no_mmcif: bool,
     overwrite: bool,
     verbose: bool,
 ) -> None:
@@ -143,15 +168,7 @@ def main(
         format="%(levelname)s: %(message)s",
         force=True,
     )
-    if output_path.exists() and not overwrite:
-        raise click.ClickException(
-            f"Output already exists: {output_path}. "
-            "Use --overwrite to replace it."
-        )
-
-    temporary = output_path.with_name(
-        f".{output_path.stem}.{uuid.uuid4().hex}.tmp{output_path.suffix}"
-    )
+    temporary = None
     try:
         structure = _read_structure(input_path)
         if input_path.suffix.lower() in (".cif", ".mmcif"):
@@ -171,12 +188,31 @@ def main(
             residue_range=residue_range,
             scfv=scfv,
         )
+        resolved_output_path = _resolve_output_path(
+            result, output_path, no_mmcif=no_mmcif
+        )
+        if resolved_output_path.exists() and not overwrite:
+            raise click.ClickException(
+                f"Output already exists: {resolved_output_path}. "
+                "Use --overwrite to replace it."
+            )
+        if resolved_output_path != output_path:
+            LOGGER.warning(
+                "PDB cannot represent multi-character insertion codes; "
+                "automatically saving mmCIF output to %s. Use --no-mmcif "
+                "to forbid this behavior.",
+                resolved_output_path,
+            )
+        temporary = resolved_output_path.with_name(
+            f".{resolved_output_path.stem}.{uuid.uuid4().hex}"
+            f".tmp{resolved_output_path.suffix}"
+        )
         _write_structure(result, temporary)
-        os.replace(temporary, output_path)
+        os.replace(temporary, resolved_output_path)
     except click.ClickException:
         raise
     except Exception as error:
-        if temporary.exists():
+        if temporary is not None and temporary.exists():
             try:
                 temporary.unlink()
             except OSError as cleanup_error:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -214,9 +214,7 @@ def test_no_mmcif_rejects_extended_insertion_codes(monkeypatch, tmp_path):
     assert list(tmp_path.iterdir()) == []
 
 
-def test_automatic_mmcif_respects_overwrite_protection(
-    monkeypatch, tmp_path
-):
+def test_automatic_mmcif_respects_overwrite_protection(monkeypatch, tmp_path):
     monkeypatch.setattr(
         cli, "renumber_structure", _with_extended_insertion_code()
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,6 +24,15 @@ def _passthrough(captured=None, fail=False):
     return fake
 
 
+def _with_extended_insertion_code():
+    def fake(structure, chain, **kwargs):
+        residue = next(structure.get_residues())
+        residue.id = (residue.id[0], residue.id[1], "AA")
+        return structure
+
+    return fake
+
+
 def test_cli_maps_the_complete_compact_interface(monkeypatch, tmp_path):
     captured = {}
     monkeypatch.setattr(cli, "renumber_structure", _passthrough(captured))
@@ -153,6 +162,82 @@ def test_cli_overwrite_protection(monkeypatch, tmp_path):
     assert result.exit_code != 0
     assert "--overwrite" in result.output
     assert output.read_text() == "existing"
+
+
+def test_cli_uses_mmcif_for_extended_insertion_codes_by_default(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr(
+        cli, "renumber_structure", _with_extended_insertion_code()
+    )
+    requested = tmp_path / "numbered.pdb"
+    output = tmp_path / "numbered.cif"
+    result = CliRunner().invoke(
+        cli.main,
+        [
+            "-i",
+            str(DATA / "test_heavy_chain.pdb"),
+            "-c",
+            "F",
+            "-o",
+            str(requested),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert not requested.exists()
+    assert output.exists()
+    assert "automatically saving mmCIF output" in result.output
+    assert "--no-mmcif" in result.output
+    parsed = MMCIFParser(QUIET=True).get_structure("output", output)
+    assert next(parsed.get_residues()).id[2] == "AA"
+
+
+def test_no_mmcif_rejects_extended_insertion_codes(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        cli, "renumber_structure", _with_extended_insertion_code()
+    )
+    output = tmp_path / "numbered.pdb"
+    result = CliRunner().invoke(
+        cli.main,
+        [
+            "-i",
+            str(DATA / "test_heavy_chain.pdb"),
+            "-c",
+            "F",
+            "-o",
+            str(output),
+            "--no-mmcif",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "printable ASCII insertion" in result.output
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_automatic_mmcif_respects_overwrite_protection(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr(
+        cli, "renumber_structure", _with_extended_insertion_code()
+    )
+    requested = tmp_path / "numbered.pdb"
+    output = tmp_path / "numbered.cif"
+    output.write_text("existing")
+    result = CliRunner().invoke(
+        cli.main,
+        [
+            "-i",
+            str(DATA / "test_heavy_chain.pdb"),
+            "-c",
+            "F",
+            "-o",
+            str(requested),
+        ],
+    )
+    assert result.exit_code != 0
+    assert "--overwrite" in result.output
+    assert output.read_text() == "existing"
+    assert not requested.exists()
 
 
 def test_cli_failure_leaves_no_output_or_temporary_file(monkeypatch, tmp_path):
@@ -426,4 +511,5 @@ def test_help_and_version_are_available():
     assert "--noise-level" in help_result.output
     assert "--scfv" in help_result.output
     assert "--mode" in help_result.output
+    assert "--no-mmcif" in help_result.output
     assert version_result.exit_code == 0


### PR DESCRIPTION
## Summary

- automatically redirect a requested `.pdb` output to the corresponding `.cif` path when renumbering produces multi-character insertion codes
- warn users about the format change and point to the new `--no-mmcif` opt-out
- preserve atomic writes and overwrite protection for the resolved output path while leaving other PDB validation limits unchanged
- document the behavior and add CLI coverage for fallback, opt-out, overwrite protection, and help output

## Why

PDB cannot represent multi-character insertion codes. Previously, users requesting PDB output received an error and had to rerun the command manually with an mmCIF filename. This makes the valid mmCIF representation the default while retaining an explicit way to forbid automatic conversion.

## Validation

- `pytest -q` — 172 passed
- `pytest --cov=sabr --cov-report=term-missing -q` — 172 passed, 96.06% coverage
- `git diff --check`
