### PR TITLE
Support multi-domain chain type candidates

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The complete interface is:
 ```text
 sabr -i INPUT -c CHAIN -o OUTPUT
      [-n imgt|chothia|kabat|martin|aho|wolfguy]
-     [-t auto|H|K|L]
+     [-t auto|TYPES]
      [--noise-level 0.0|0.2|0.5|1.0|2.0]
      [-m sabr|softalign]
      [--residue-range START END]
@@ -38,22 +38,25 @@ sabr -i INPUT -c CHAIN -o OUTPUT
 ```
 
 Defaults are IMGT numbering, automatic H/K/L selection, noise level `0.0`,
-`sabr` mode, and the entire selected chain. Existing outputs are never
-replaced unless `--overwrite` is given. Normal output contains only warnings
-and errors; `-v` reports reference scores and pipeline decisions.
+`sabr` mode, and the entire selected chain. `--chain-type` accepts an ordered,
+comma-separated list of candidates. Each candidate is a sequence of `H`, `K`,
+and `L` domains: `H,K` tries heavy and kappa single domains, `HK,HL` tries
+heavy-kappa and heavy-lambda two-domain chains, and `HHK,HHL` tries the
+corresponding three-domain chains. Existing outputs are never replaced unless
+`--overwrite` is given. Normal output contains only warnings and errors; `-v`
+reports reference scores and pipeline decisions.
 
 Use `--mode softalign` to select the original SoftAlign encoder weights,
 reference embeddings, and affine gap penalties together. SoftAlign references
 do not vary with `--noise-level`, so that option is ignored in this mode.
 
-Use `--scfv` for a single chain containing two linked variable domains. In
-addition to the H, K, and L references, this mode tries the concatenated H:K,
-H:L, K:H, and L:H representations. The second domain is numbered with a 128
-offset so both domains have unique residue IDs in one structure chain; linker
-residues use insertion codes after the first domain. Because each composite
-already specifies both domain types, scFv mode requires automatic chain type.
-Composite references use the selected parameter mode, so `--scfv` can be
-combined with `--mode softalign`.
+Use `--scfv` to search only the scFv candidate set. It is equivalent to
+`--chain-type HK,HL,KH,LH` and still requires the default automatic chain type
+when used as a flag. Each domain after the first is numbered with another 128
+offset so all domains have unique residue IDs in one structure chain; linker
+residues use insertion codes after the preceding domain. Multi-domain
+references use the selected parameter mode, so either form can be combined
+with `--mode softalign`.
 
 Input and output may be PDB (`.pdb`) or mmCIF (`.cif` or `.mmcif`). Use mmCIF
 when chain names or ANARCI insertion codes exceed PDB's one-character fields.
@@ -84,7 +87,7 @@ numbered = renumber_structure(
     structure,
     chain="heavy_chain",
     scheme="chothia",
-    chain_type="auto",
+    chain_type="H,K,HK,HL",
     noise_level=0.0,
     mode="softalign",
     residue_range=None,
@@ -136,12 +139,14 @@ the CLI with mmCIF output.
 - No deterministic C-terminal correction is applied.
 - Automatic chain selection aligns against H, K, and L references and uses
   the highest score, with deterministic H/K/L tie order.
-- scFv mode appends H:K, H:L, K:H, and L:H reference candidates in that order.
-- Composite candidates do not apply gap-open or gap-extension costs to query
-  linker residues aligned at the boundary between their two references.
-- Composite candidates receive normal affine gap-open and gap-extension costs
-  for unaligned query and reference termini when their selection scores are
-  compared; the underlying alignments and raw alignment scores are unchanged.
+- `chain_type` candidate order is deterministic and resolves score ties.
+- scFv mode searches only the `HK,HL,KH,LH` candidate list in that order.
+- Multi-domain candidates do not apply gap-open or gap-extension costs to
+  query linker residues aligned at any boundary between domain references.
+- Multi-domain candidates receive normal affine gap-open and gap-extension
+  costs for unaligned query and reference termini when their selection scores
+  are compared; the underlying alignments and raw alignment scores are
+  unchanged.
 
 A structural gap is detected when the C–N distance between consecutive
 residues exceeds 2.66 Å. A gap skips only the affected CDR or DE-loop

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ sabr -i INPUT -c CHAIN -o OUTPUT
 ```
 
 Defaults are IMGT numbering, automatic H/K/L selection, noise level `0.0`,
-`sabr` mode, and the entire selected chain. `--chain-type` accepts an ordered,
-comma-separated list of candidates. Each candidate is a sequence of `H`, `K`,
+`sabr` mode, and the entire selected chain. `--chain-type` accepts a
+comma-separated set of candidates. Each candidate is a sequence of `H`, `K`,
 and `L` domains: `H,K` tries heavy and kappa single domains, `HK,HL` tries
 heavy-kappa and heavy-lambda two-domain chains, and `HHK,HHL` tries the
 corresponding three-domain chains. Existing outputs are never replaced unless

--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ do not vary with `--noise-level`, so that option is ignored in this mode.
 
 Use `--scfv` to search only the scFv candidate set. It is equivalent to
 `--chain-type HK,HL,KH,LH` and still requires the default automatic chain type
-when used as a flag. Each domain after the first is numbered with another 128
-offset so all domains have unique residue IDs in one structure chain; linker
-residues use insertion codes after the preceding domain. Multi-domain
-references use the selected parameter mode, so either form can be combined
-with `--mode softalign`.
+when used as a flag. Multi-domain results place successive domains in separate
+1000-number residue blocks: `1–128`, `1001–1128`, `2001–2128`, and so on.
+Linker residues continue sequentially from the preceding domain's last number.
+Multi-domain references use the selected parameter mode, so either form can be
+combined with `--mode softalign`.
 
 Input and output may be PDB (`.pdb`) or mmCIF (`.cif` or `.mmcif`). Use mmCIF
 when chain names or ANARCI insertion codes exceed PDB's one-character fields.

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,18 @@ sabr -i antibody.cif -c light_chain -o numbered.cif \
   --scheme chothia --chain-type K
 ```
 
+Pass comma-separated candidates to restrict automatic selection. Every
+candidate is an ordered sequence of `H`, `K`, and `L` domains:
+
+```bash
+sabr -i multispecific.cif -c A -o numbered.cif \
+  --chain-type HHK,HHL
+```
+
+For example, `H,K` tries only heavy and kappa single domains, while `HK,HL`
+tries heavy-kappa and heavy-lambda two-domain chains. `HHK,HHL` can represent
+a VHH followed by an scFv whose heavy domain precedes its light domain.
+
 Use the complete SoftAlign parameter set (encoder, reference embeddings, and
 gap penalties):
 
@@ -50,7 +62,7 @@ The complete interface is:
 ```text
 sabr -i INPUT -c CHAIN -o OUTPUT
      [-n imgt|chothia|kabat|martin|aho|wolfguy]
-     [-t auto|H|K|L]
+     [-t auto|TYPES]
      [--noise-level 0.0|0.2|0.5|1.0|2.0]
      [-m sabr|softalign]
      [--residue-range START END]
@@ -64,20 +76,19 @@ ignored in that mode. Normal output contains only warnings and errors. Use
 `--verbose` to show the JAX backend, chain-selection scores, and a traceback
 on failure.
 
-For a single chain containing two linked variable domains, pass `--scfv`.
-This adds H:K, H:L, K:H, and L:H concatenated references to the normal H, K,
-and L candidates. SAbR offsets the second domain's assigned numbers by 128 to
-keep residue IDs unique and numbers the linker as insertions after domain one.
-scFv mode requires the default automatic chain type because each composite
-reference already specifies both domain types.
-Composite references use the selected parameter mode, so `--scfv` can be
-combined with `--mode softalign`.
-Gap-open and gap-extension penalties are disabled for query linker residues
-aligned at the boundary between the two references. All other internal gap
-transitions retain the selected parameter mode's normal penalties.
+To search only the scFv candidate set, pass `--scfv`. This is equivalent to
+`--chain-type HK,HL,KH,LH`; as a compatibility flag it requires the default
+automatic chain type. SAbR offsets each successive
+domain's assigned numbers by another 128 to keep residue IDs unique and
+numbers every linker as insertions after the preceding domain. Multi-domain
+references use the selected parameter mode, so either form can be combined
+with `--mode softalign`. Gap-open and gap-extension penalties are disabled for
+query linker residues aligned at every boundary between domain references.
+All other internal gap transitions retain the selected parameter mode's
+normal penalties.
 
 When candidates are compared, SAbR applies the normal affine gap-open and
-gap-extension costs to unaligned query and reference termini of composite
+gap-extension costs to unaligned query and reference termini of multi-domain
 representations. This post-hoc selection penalty does not change the computed
 alignments or their raw scores.
 
@@ -192,5 +203,6 @@ Common errors include:
 - output that cannot be represented in PDB format; and
 - selections above the 1,024-residue safety limit.
 
-For long or multi-domain chains, pass `--residue-range` on the command line or
-`residue_range=(start, end)` in Python.
+For a long chain containing domains outside the desired candidate, pass
+`--residue-range` on the command line or `residue_range=(start, end)` in
+Python.

--- a/docs/index.md
+++ b/docs/index.md
@@ -78,9 +78,9 @@ on failure.
 
 To search only the scFv candidate set, pass `--scfv`. This is equivalent to
 `--chain-type HK,HL,KH,LH`; as a compatibility flag it requires the default
-automatic chain type. SAbR offsets each successive
-domain's assigned numbers by another 128 to keep residue IDs unique and
-numbers every linker as insertions after the preceding domain. Multi-domain
+automatic chain type. SAbR places successive domains in separate 1000-number
+residue blocks: `1–128`, `1001–1128`, `2001–2128`, and so on. Every linker
+continues sequentially from the preceding domain's last number. Multi-domain
 references use the selected parameter mode, so either form can be combined
 with `--mode softalign`. Gap-open and gap-extension penalties are disabled for
 query linker residues aligned at every boundary between domain references.

--- a/src/sabr/alignment.py
+++ b/src/sabr/alignment.py
@@ -174,15 +174,14 @@ def load_references(
         )
 
     if scfv:
-        for representation in constants.SCFV_CHAIN_TYPES:
-            first_type, second_type = representation
+        for first_type, second_type in constants.SCFV_CHAIN_TYPES:
             first_embeddings, first_positions = references[first_type]
             second_embeddings, second_positions = references[second_type]
             embeddings = np.concatenate(
                 (first_embeddings, second_embeddings), axis=0
             )
             embeddings.flags.writeable = False
-            references[representation] = (
+            references[first_type + second_type] = (
                 embeddings,
                 (
                     *first_positions,
@@ -347,7 +346,7 @@ def align(
     references = dict(load_references(noise_level, mode, scfv=scfv))
     if chain_type == "auto":
         candidates = (
-            constants.SCFV_CANDIDATES if scfv else constants.CHAIN_TYPES
+            constants.SCFV_CHAIN_TYPES if scfv else constants.CHAIN_TYPES
         )
     else:
         candidates = tuple(chain_type.split(","))
@@ -408,7 +407,7 @@ def align(
             )
 
     _, score, selected_type, reduced, positions = best
-    domain_count = (max(positions) - 1) // constants.IMGT_MAX_POSITION + 1
+    domain_count = len(selected_type)
     full_alignment = np.zeros(
         (query.shape[0], domain_count * constants.IMGT_MAX_POSITION),
         dtype=reduced.dtype,

--- a/src/sabr/alignment.py
+++ b/src/sabr/alignment.py
@@ -21,7 +21,10 @@ def _rotate_for_dp(x, NINF, free_gap_boundary=-1):
     br = jnp.arange(b)[None, :]
     i, j = (br - ar) + (a - 1), (ar + br) // 2
     n, m = (a + b - 1), (a + b) // 2
-    free_gap = jnp.broadcast_to(br == free_gap_boundary, (a, b))
+    boundaries = jnp.atleast_1d(jnp.asarray(free_gap_boundary))
+    free_gap = jnp.broadcast_to(
+        jnp.any(br[..., None] == boundaries, axis=-1), (a, b)
+    )
     output = {
         "x": jnp.full([n, m], NINF).at[i, j].set(x),
         "o": (jnp.arange(n) + a % 2) % 2,
@@ -75,7 +78,7 @@ def _affine_score(
     free_gap_boundary=-1,
     NINF=-1e30,
 ):
-    """Return a score, optionally making one reference gap boundary free."""
+    """Return a score, optionally making reference gap boundaries free."""
     right_penalties = jnp.asarray(
         [
             gap_open,
@@ -172,7 +175,7 @@ def load_references(
 
     if scfv:
         for representation in constants.SCFV_CHAIN_TYPES:
-            first_type, second_type = representation.split(":")
+            first_type, second_type = representation
             first_embeddings, first_positions = references[first_type]
             second_embeddings, second_positions = references[second_type]
             embeddings = np.concatenate(
@@ -229,35 +232,55 @@ def _alignment_path(alignment: np.ndarray) -> np.ndarray:
     return path
 
 
-def _validate_scfv_alignment(
+def _validate_multidomain_alignment(
     alignment: np.ndarray, representation: str
 ) -> None:
-    """Validate two ordered IMGT-domain blocks with an optional linker."""
-    expected_columns = 2 * constants.IMGT_MAX_POSITION
+    """Validate ordered IMGT-domain blocks with optional linkers."""
+    expected_columns = len(representation) * constants.IMGT_MAX_POSITION
     if alignment.ndim != 2 or alignment.shape[1] != expected_columns:
         raise ValueError(
-            f"scFv alignment must have {expected_columns} columns."
+            f"Multi-domain alignment must have {expected_columns} columns."
         )
     _alignment_path(alignment)
 
-    for domain_index, chain_type in enumerate(representation.split(":")):
+    for domain_index, chain_type in enumerate(representation):
         start = domain_index * constants.IMGT_MAX_POSITION
         end = start + constants.IMGT_MAX_POSITION
         domain = alignment[:, start:end]
         assigned_rows = np.flatnonzero(domain.sum(axis=1))
         if not len(assigned_rows):
             raise ValueError(
-                f"scFv {chain_type} domain contains no assigned residues."
+                f"Multi-domain {chain_type} domain {domain_index + 1} "
+                "contains no assigned residues."
             )
+
+
+# Kept as a private compatibility alias for callers of the former helper.
+_validate_scfv_alignment = _validate_multidomain_alignment
+
+
+def _concatenate_reference(references: dict, representation: str) -> tuple:
+    """Build one ordered multi-domain reference from single domains."""
+    domain_references = [references[domain] for domain in representation]
+    embeddings = np.concatenate(
+        [reference[0] for reference in domain_references], axis=0
+    )
+    embeddings.flags.writeable = False
+    positions = tuple(
+        position + domain_index * constants.IMGT_MAX_POSITION
+        for domain_index, (_, domain_positions) in enumerate(domain_references)
+        for position in domain_positions
+    )
+    return embeddings, positions
 
 
 def _align_reference(
     query: np.ndarray,
     reference: np.ndarray,
     mode: str = "sabr",
-    free_gap_boundary: int = -1,
+    free_gap_boundary: int | tuple[int, ...] = -1,
 ):
-    """Align one reference, optionally allowing a free query insertion."""
+    """Align one reference, optionally allowing free query insertions."""
     anchor = np.zeros((1, reference.shape[1]), dtype=reference.dtype)
     augmented_reference = np.concatenate((anchor, reference, anchor), axis=0)
     query_batch = jnp.asarray(query[None, :])
@@ -325,21 +348,33 @@ def align(
     scfv: bool = False,
 ) -> tuple:
     """Align query embeddings and return corrected IMGT alignment metadata."""
-    references = load_references(noise_level, mode, scfv=scfv)
-    candidates = tuple(references) if chain_type == "auto" else (chain_type,)
+    references = dict(load_references(noise_level, mode, scfv=scfv))
+    if chain_type == "auto":
+        candidates = (
+            constants.SCFV_CANDIDATES if scfv else constants.CHAIN_TYPES
+        )
+    else:
+        candidates = tuple(chain_type.split(","))
     best = None
     for candidate in candidates:
+        if candidate not in references:
+            references[candidate] = _concatenate_reference(
+                references, candidate
+            )
         reference, positions = references[candidate]
-        if ":" in candidate:
-            free_gap_boundary = sum(
-                position <= constants.IMGT_MAX_POSITION
-                for position in positions
+        if len(candidate) > 1:
+            free_gap_boundaries = tuple(
+                sum(
+                    position <= domain_index * constants.IMGT_MAX_POSITION
+                    for position in positions
+                )
+                for domain_index in range(1, len(candidate))
             )
             reduced, similarity, score = _align_reference(
                 query,
                 reference,
                 mode,
-                free_gap_boundary=free_gap_boundary,
+                free_gap_boundary=free_gap_boundaries,
             )
         else:
             reduced, similarity, score = _align_reference(
@@ -354,7 +389,7 @@ def align(
                 f"{candidate} reference produced a non-finite alignment."
             )
         selection_score = score
-        if ":" in candidate:
+        if len(candidate) > 1:
             terminal_penalty = _terminal_gap_penalty(reduced, mode)
             selection_score += terminal_penalty
             LOGGER.info(
@@ -384,16 +419,16 @@ def align(
     )
     full_alignment[:, np.asarray(positions) - 1] = reduced
     full_alignment = np.round(full_alignment).astype(int)
-    if ":" in selected_type:
+    if len(selected_type) > 1:
         corrected = full_alignment.copy()
-        for domain_index, _ in enumerate(selected_type.split(":")):
+        for domain_index, _ in enumerate(selected_type):
             start = domain_index * constants.IMGT_MAX_POSITION
             end = start + constants.IMGT_MAX_POSITION
             corrected[:, start:end] = apply_corrections(
                 corrected[:, start:end],
                 gap_indices=gap_indices,
             )
-        _validate_scfv_alignment(corrected, selected_type)
+        _validate_multidomain_alignment(corrected, selected_type)
     else:
         corrected = apply_corrections(full_alignment, gap_indices=gap_indices)
         _alignment_path(corrected)

--- a/src/sabr/alignment.py
+++ b/src/sabr/alignment.py
@@ -255,10 +255,6 @@ def _validate_multidomain_alignment(
             )
 
 
-# Kept as a private compatibility alias for callers of the former helper.
-_validate_scfv_alignment = _validate_multidomain_alignment
-
-
 def _concatenate_reference(references: dict, representation: str) -> tuple:
     """Build one ordered multi-domain reference from single domains."""
     domain_references = [references[domain] for domain in representation]

--- a/src/sabr/api.py
+++ b/src/sabr/api.py
@@ -11,6 +11,33 @@ from sabr.structure import apply_numbering, extract_chain
 LOGGER = logging.getLogger(__name__)
 
 
+def _normalize_chain_type(chain_type: str) -> str:
+    """Normalize an automatic or comma-separated domain candidate list."""
+    if not isinstance(chain_type, str):
+        raise ValueError(
+            "chain_type must be 'auto' or a comma-separated list of H, K, "
+            "and L domain representations."
+        )
+
+    if chain_type.strip().lower() == "auto":
+        return "auto"
+
+    candidates = []
+    for value in chain_type.split(","):
+        candidate = value.strip().upper()
+        if not candidate or any(
+            domain_type not in constants.CHAIN_TYPES
+            for domain_type in candidate
+        ):
+            raise ValueError(
+                "chain_type must be 'auto' or a comma-separated list of H, "
+                "K, and L domain representations."
+            )
+        if candidate not in candidates:
+            candidates.append(candidate)
+    return ",".join(candidates)
+
+
 def _validate_options(
     scheme: str,
     chain_type: str,
@@ -26,13 +53,7 @@ def _validate_options(
         raise ValueError(
             f"scheme must be one of {', '.join(constants.NUMBERING_SCHEMES)}."
         )
-    if not isinstance(chain_type, str):
-        raise ValueError("chain_type must be 'auto', 'H', 'K', or 'L'.")
-    normalized_chain_type = (
-        "auto" if chain_type.lower() == "auto" else chain_type.upper()
-    )
-    if normalized_chain_type not in ("auto", *constants.CHAIN_TYPES):
-        raise ValueError("chain_type must be 'auto', 'H', 'K', or 'L'.")
+    normalized_chain_type = _normalize_chain_type(chain_type)
     if isinstance(noise_level, bool):
         raise ValueError(
             f"noise_level must be one of {constants.NOISE_LEVELS}."
@@ -67,6 +88,8 @@ def _validate_options(
         raise ValueError("scfv must be a boolean.")
     if scfv and normalized_chain_type != "auto":
         raise ValueError("scfv requires chain_type='auto'.")
+    if scfv:
+        normalized_chain_type = ",".join(constants.SCFV_CANDIDATES)
     return (
         scheme.lower(),
         normalized_chain_type,
@@ -89,8 +112,10 @@ def renumber_structure(
     """Return a non-mutating, same-type renumbered structure.
 
     ``mode="softalign"`` selects the SoftAlign encoder, references, and gap
-    penalties as one scientifically consistent parameter set. ``scfv=True``
-    adds the four supported two-domain composite references.
+    penalties as one scientifically consistent parameter set. ``chain_type``
+    accepts an ordered, comma-separated list of domain representations such
+    as ``"H,K,HK,HL"``. ``scfv=True`` is equivalent to
+    ``chain_type="HK,HL,KH,LH"``.
     """
     scheme, chain_type, noise_level, mode, scfv = _validate_options(
         scheme, chain_type, noise_level, residue_range, mode, scfv

--- a/src/sabr/api.py
+++ b/src/sabr/api.py
@@ -25,30 +25,22 @@ def _normalize_chain_type(
     mode: str,
 ) -> str:
     """Normalize an automatic or comma-separated domain candidate list."""
-    if not isinstance(chain_type, str):
-        raise ValueError(
-            "chain_type must be 'auto' or a comma-separated list of H, K, "
-            "and L domain representations."
-        )
-
     if chain_type.strip().lower() == "auto":
         return "auto"
 
     reference_types = tuple(load_references(noise_level, mode))
-    choices = ", ".join(("auto", *reference_types))
-    error = (
-        "chain_type must be 'auto' or comma-separated representations "
-        f"built from {choices}."
+    candidates = sorted(
+        {value.strip().upper() for value in chain_type.split(",")}
     )
-    candidates = []
-    for value in chain_type.split(","):
-        candidate = value.strip().upper()
-        if not candidate or any(
-            domain_type not in reference_types for domain_type in candidate
-        ):
-            raise ValueError(error)
-        if candidate not in candidates:
-            candidates.append(candidate)
+    if any(
+        not candidate or not set(candidate).issubset(reference_types)
+        for candidate in candidates
+    ):
+        choices = ", ".join(("auto", *reference_types))
+        raise ValueError(
+            "chain_type must be 'auto' or comma-separated representations "
+            f"built from {choices}."
+        )
     return ",".join(candidates)
 
 
@@ -124,7 +116,7 @@ class _RenumberOptions:
         if self.scfv and self.chain_type != "auto":
             raise ValueError("scfv requires chain_type='auto'.")
         if self.scfv:
-            self.chain_type = ",".join(constants.SCFV_CANDIDATES)
+            self.chain_type = ",".join(constants.SCFV_CHAIN_TYPES)
 
 
 def renumber_structure(
@@ -141,7 +133,7 @@ def renumber_structure(
 
     ``mode="softalign"`` selects the SoftAlign encoder, references, and gap
     penalties as one scientifically consistent parameter set. ``chain_type``
-    accepts an ordered, comma-separated list of domain representations such
+    accepts a comma-separated set of domain representations such
     as ``"H,K,HK,HL"``. ``scfv=True`` is equivalent to
     ``chain_type="HK,HL,KH,LH"``.
     """

--- a/src/sabr/cli.py
+++ b/src/sabr/cli.py
@@ -97,8 +97,11 @@ def _write_structure(structure, path: Path) -> None:
     "--chain-type",
     default="auto",
     show_default=True,
-    type=click.Choice(("auto", *constants.CHAIN_TYPES), case_sensitive=True),
-    help="Reference and ANARCI chain type.",
+    metavar="TYPES",
+    help=(
+        "Comma-separated reference domain representations, such as H,K or "
+        "HK,HL."
+    ),
 )
 @click.option(
     "--noise-level",
@@ -120,7 +123,7 @@ def _write_structure(structure, path: Path) -> None:
 @click.option(
     "--scfv",
     is_flag=True,
-    help="Also try H:K, H:L, K:H, and L:H composite references.",
+    help="Equivalent to --chain-type HK,HL,KH,LH.",
 )
 @click.option("--overwrite", is_flag=True)
 @click.option("-v", "--verbose", is_flag=True)

--- a/src/sabr/constants.py
+++ b/src/sabr/constants.py
@@ -31,7 +31,8 @@ SW_GAP_OPEN = -2.525591
 # SoftAlign params
 DEFAULT_TEMPERATURE = 1e-4
 CHAIN_TYPES = ("H", "K", "L")
-SCFV_CHAIN_TYPES = ("H:K", "H:L", "K:H", "L:H")
+SCFV_CHAIN_TYPES = ("HK", "HL", "KH", "LH")
+SCFV_CANDIDATES = SCFV_CHAIN_TYPES
 NOISE_LEVELS = (0.0, 0.2, 0.5, 1.0, 2.0)
 MODES = ("sabr", "softalign")
 NUMBERING_SCHEMES = ("imgt", "chothia", "kabat", "martin", "aho", "wolfguy")

--- a/src/sabr/constants.py
+++ b/src/sabr/constants.py
@@ -41,6 +41,7 @@ NUMBERING_SCHEMES = ("imgt", "chothia", "kabat", "martin", "aho", "wolfguy")
 # IMGT constants
 
 IMGT_MAX_POSITION = 128
+DOMAIN_NUMBERING_STRIDE = 1000
 
 # CDR loop definitions (inclusive)
 IMGT_LOOPS = {

--- a/src/sabr/constants.py
+++ b/src/sabr/constants.py
@@ -32,7 +32,6 @@ SW_GAP_OPEN = -2.525591
 DEFAULT_TEMPERATURE = 1e-4
 CHAIN_TYPES = ("H", "K", "L")
 SCFV_CHAIN_TYPES = ("HK", "HL", "KH", "LH")
-SCFV_CANDIDATES = SCFV_CHAIN_TYPES
 NOISE_LEVELS = (0.0, 0.2, 0.5, 1.0, 2.0)
 MODES = ("sabr", "softalign")
 NUMBERING_SCHEMES = ("imgt", "chothia", "kabat", "martin", "aho", "wolfguy")

--- a/src/sabr/numbering.py
+++ b/src/sabr/numbering.py
@@ -270,10 +270,10 @@ def number_alignment(
     """Return query-row-to-number records for one alignment.
 
     ``ref_type`` and ``ref_positions`` are opt-in metadata for reduced
-    single-domain references. Normal 128-column antibody and 256-column scFv
+    single-domain references. Normal full-width single- and multi-domain
     alignments leave them unset.
     """
-    if ":" not in chain_type:
+    if len(chain_type) == 1:
         return _number_domain_alignment(
             alignment,
             sequence,
@@ -289,11 +289,11 @@ def number_alignment(
             "alignments."
         )
 
-    chain_types = chain_type.split(":")
+    chain_types = tuple(chain_type)
     expected_columns = len(chain_types) * constants.IMGT_MAX_POSITION
     if alignment.ndim != 2 or alignment.shape[1] != expected_columns:
         raise ValueError(
-            f"scFv alignment must have {expected_columns} columns."
+            f"Multi-domain alignment must have {expected_columns} columns."
         )
 
     domains = []
@@ -307,7 +307,7 @@ def number_alignment(
             records = [
                 (
                     query_row,
-                    number + constants.IMGT_MAX_POSITION,
+                    number + domain_index * constants.IMGT_MAX_POSITION,
                     insertion_code,
                     amino_acid,
                 )
@@ -315,27 +315,32 @@ def number_alignment(
             ]
         domains.append(records)
 
-    first_domain, second_domain = domains
-    linker_start = first_domain[-1][0] + 1
-    linker_end = second_domain[0][0]
-    used_ids = {
-        (number, insertion_code)
-        for _, number, insertion_code, _ in first_domain
-    }
-    linker_number = first_domain[-1][1]
-    available_codes = (
-        code
-        for code in schemes.alphabet
-        if code.strip() and (linker_number, code) not in used_ids
-    )
-    linker = [
-        (query_row, linker_number, next(available_codes), sequence[query_row])
-        for query_row in range(linker_start, linker_end)
-    ]
-
-    records = [*first_domain, *linker, *second_domain]
+    records = list(domains[0])
+    for previous_domain, next_domain in zip(domains, domains[1:]):
+        linker_start = previous_domain[-1][0] + 1
+        linker_end = next_domain[0][0]
+        used_ids = {
+            (number, insertion_code)
+            for _, number, insertion_code, _ in previous_domain
+        }
+        linker_number = previous_domain[-1][1]
+        available_codes = (
+            code
+            for code in schemes.alphabet
+            if code.strip() and (linker_number, code) not in used_ids
+        )
+        records.extend(
+            (
+                query_row,
+                linker_number,
+                next(available_codes),
+                sequence[query_row],
+            )
+            for query_row in range(linker_start, linker_end)
+        )
+        records.extend(next_domain)
     LOGGER.info(
-        "Numbered %d residues as scFv %s using %s.",
+        "Numbered %d residues as multi-domain %s using %s.",
         len(records),
         chain_type,
         scheme,

--- a/src/sabr/numbering.py
+++ b/src/sabr/numbering.py
@@ -307,7 +307,7 @@ def number_alignment(
             records = [
                 (
                     query_row,
-                    number + domain_index * constants.IMGT_MAX_POSITION,
+                    number + domain_index * constants.DOMAIN_NUMBERING_STRIDE,
                     insertion_code,
                     amino_acid,
                 )
@@ -319,24 +319,16 @@ def number_alignment(
     for previous_domain, next_domain in zip(domains, domains[1:]):
         linker_start = previous_domain[-1][0] + 1
         linker_end = next_domain[0][0]
-        used_ids = {
-            (number, insertion_code)
-            for _, number, insertion_code, _ in previous_domain
-        }
-        linker_number = previous_domain[-1][1]
-        available_codes = (
-            code
-            for code in schemes.alphabet
-            if code.strip() and (linker_number, code) not in used_ids
-        )
         records.extend(
             (
                 query_row,
-                linker_number,
-                next(available_codes),
+                previous_domain[-1][1] + linker_index,
+                "",
                 sequence[query_row],
             )
-            for query_row in range(linker_start, linker_end)
+            for linker_index, query_row in enumerate(
+                range(linker_start, linker_end), start=1
+            )
         )
         records.extend(next_domain)
     LOGGER.info(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -171,13 +171,13 @@ def test_softalign_mode_is_forwarded_to_encoder_and_alignment(monkeypatch):
 @pytest.mark.parametrize(
     ("chain_type", "normalized"),
     [
-        ("h, k", "H,K"),
+        ("k, h", "H,K"),
         ("HK,HL", "HK,HL"),
         ("hhk, hhl", "HHK,HHL"),
         ("H,H,K", "H,K"),
     ],
 )
-def test_chain_type_accepts_ordered_domain_candidate_lists(
+def test_chain_type_accepts_domain_candidate_sets(
     monkeypatch, chain_type, normalized
 ):
     captured = {}
@@ -280,7 +280,6 @@ def test_multiple_models_are_rejected():
         ({"noise_level": 0.3}, "noise_level"),
         ({"residue_range": [1, 2]}, "residue_range"),
         ({"residue_range": (2, 1)}, "start"),
-        ({"chain_type": None}, "chain_type"),
         ({"noise_level": "invalid"}, "noise_level"),
         ({"noise_level": False}, "noise_level"),
         ({"mode": "other"}, "mode"),

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -33,7 +33,7 @@ def _gemmi_ids(structure, chain):
     ]
 
 
-def _stub_pipeline(monkeypatch, captured_modes=None):
+def _stub_pipeline(monkeypatch, captured_modes=None, captured_options=None):
     def fake_encode(coords, mode):
         if captured_modes is not None:
             captured_modes["encoder"] = mode
@@ -42,6 +42,8 @@ def _stub_pipeline(monkeypatch, captured_modes=None):
     def fake_align(embeddings, gaps, chain_type, noise, mode, scfv):
         if captured_modes is not None:
             captured_modes["alignment"] = mode
+        if captured_options is not None:
+            captured_options.update({"chain_type": chain_type, "scfv": scfv})
         return (
             np.zeros((len(embeddings), 128), dtype=int),
             "H" if chain_type == "auto" else chain_type,
@@ -176,6 +178,40 @@ def test_softalign_mode_is_forwarded_to_encoder_and_alignment(monkeypatch):
     }
 
 
+@pytest.mark.parametrize(
+    ("chain_type", "normalized"),
+    [
+        ("h, k", "H,K"),
+        ("HK,HL", "HK,HL"),
+        ("hhk, hhl", "HHK,HHL"),
+        ("H,H,K", "H,K"),
+    ],
+)
+def test_chain_type_accepts_ordered_domain_candidate_lists(
+    monkeypatch, chain_type, normalized
+):
+    captured = {}
+    _stub_pipeline(monkeypatch, captured_options=captured)
+    structure = PDBParser(QUIET=True).get_structure(
+        "heavy", DATA / "test_heavy_chain.pdb"
+    )
+    renumber_structure(structure, "F", chain_type=chain_type)
+    assert captured == {"chain_type": normalized, "scfv": False}
+
+
+def test_scfv_is_the_documented_chain_type_alias(monkeypatch):
+    captured = {}
+    _stub_pipeline(monkeypatch, captured_options=captured)
+    structure = PDBParser(QUIET=True).get_structure(
+        "heavy", DATA / "test_heavy_chain.pdb"
+    )
+    renumber_structure(structure, "F", scfv=True)
+    assert captured == {
+        "chain_type": "HK,HL,KH,LH",
+        "scfv": True,
+    }
+
+
 def test_missing_backbone_is_reported_with_the_residue():
     structure = PDBParser(QUIET=True).get_structure(
         "missing", DATA / "test_no_backbone.pdb"
@@ -222,6 +258,8 @@ def test_multiple_models_are_rejected():
     [
         ({"scheme": "unknown"}, "scheme"),
         ({"chain_type": "heavy"}, "chain_type"),
+        ({"chain_type": "H,,K"}, "chain_type"),
+        ({"chain_type": "auto,H"}, "chain_type"),
         ({"noise_level": 0.3}, "noise_level"),
         ({"residue_range": [1, 2]}, "residue_range"),
         ({"residue_range": (2, 1)}, "start"),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -135,6 +135,29 @@ def test_cli_forwards_scfv_mode(monkeypatch, tmp_path):
     assert captured["scfv"] is True
 
 
+@pytest.mark.parametrize("chain_type", ("H,K", "HK,HL", "HHK,HHL"))
+def test_cli_forwards_comma_separated_domain_candidates(
+    monkeypatch, tmp_path, chain_type
+):
+    captured = {}
+    monkeypatch.setattr(cli, "renumber_structure", _passthrough(captured))
+    result = CliRunner().invoke(
+        cli.main,
+        [
+            "-i",
+            str(DATA / "test_heavy_chain.pdb"),
+            "-c",
+            "F",
+            "-o",
+            str(tmp_path / f"{chain_type.replace(',', '-')}.pdb"),
+            "--chain-type",
+            chain_type,
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["chain_type"] == chain_type
+
+
 def test_cli_overwrite_protection(monkeypatch, tmp_path):
     monkeypatch.setattr(cli, "renumber_structure", _passthrough())
     output = tmp_path / "exists.pdb"
@@ -187,7 +210,7 @@ def test_real_cli_round_trip(monkeypatch, tmp_path):
             "-o",
             str(output),
             "-t",
-            "H",
+            "H,K",
         ],
     )
     assert result.exit_code == 0, result.output

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -11,6 +11,7 @@ from sabr.alignment import (
     _affine_score,
     _align_reference,
     _alignment_path,
+    _concatenate_reference,
     _terminal_gap_penalty,
     _validate_scfv_alignment,
     align,
@@ -133,7 +134,7 @@ def test_scfv_references_are_exact_ordered_concatenations(mode, noise_level):
         *constants.SCFV_CHAIN_TYPES,
     )
     for representation in constants.SCFV_CHAIN_TYPES:
-        first_type, second_type = representation.split(":")
+        first_type, second_type = representation
         embeddings, positions = references[representation]
         first_embeddings, first_positions = references[first_type]
         second_embeddings, second_positions = references[second_type]
@@ -157,7 +158,27 @@ def test_scfv_alignment_allows_an_unassigned_linker_between_domains():
     alignment[1, 1] = 1
     alignment[3, 128] = 1
     alignment[4, 129] = 1
-    _validate_scfv_alignment(alignment, "H:K")
+    _validate_scfv_alignment(alignment, "HK")
+
+
+def test_higher_order_reference_is_an_ordered_concatenation():
+    references = load_references(0.0)
+    embeddings, positions = _concatenate_reference(references, "HHK")
+    expected_embeddings = np.concatenate(
+        (
+            references["H"][0],
+            references["H"][0],
+            references["K"][0],
+        ),
+        axis=0,
+    )
+    np.testing.assert_array_equal(embeddings, expected_embeddings)
+    assert positions == tuple(
+        position + domain_index * constants.IMGT_MAX_POSITION
+        for domain_index, domain_type in enumerate("HHK")
+        for position in references[domain_type][1]
+    )
+    assert not embeddings.flags.writeable
 
 
 @pytest.mark.parametrize("linker_length", (1, 3))
@@ -190,6 +211,34 @@ def test_scfv_reference_boundary_has_no_affine_linker_penalty(linker_length):
     expected_penalty = gap_open + (linker_length - 1) * gap_extend
     assert float(penalized) == pytest.approx(20.0 + expected_penalty)
     assert float(free) == pytest.approx(20.0)
+
+
+def test_higher_order_reference_makes_every_linker_boundary_free():
+    similarities = np.full((5, 5), -100.0, dtype=np.float32)
+    similarities[:, (0, 4)] = 0.0
+    similarities[0, 1] = 10.0
+    similarities[2, 2] = 10.0
+    similarities[4, 3] = 10.0
+    lengths = np.asarray(similarities.shape)
+
+    penalized = _affine_score(
+        similarities,
+        lengths,
+        1e-4,
+        gap_extend=-1.0,
+        gap_open=-3.0,
+    )
+    free = _affine_score(
+        similarities,
+        lengths,
+        1e-4,
+        gap_extend=-1.0,
+        gap_open=-3.0,
+        free_gap_boundary=(1, 2),
+    )
+
+    assert float(penalized) == pytest.approx(24.0)
+    assert float(free) == pytest.approx(30.0)
 
 
 def test_softalign_mode_loads_its_complete_parameter_set():
@@ -307,7 +356,7 @@ def test_scfv_mode_selects_and_corrects_a_composite_reference(monkeypatch):
     )
     references = {}
     for index, representation in enumerate(representations):
-        domain_count = 2 if ":" in representation else 1
+        domain_count = len(representation)
         references[representation] = (
             np.full((domain_count, 64), index),
             [1, 129] if domain_count == 2 else [1],
@@ -321,7 +370,10 @@ def test_scfv_mode_selects_and_corrects_a_composite_reference(monkeypatch):
         marker = int(reference[0, 0])
         representation = representations[marker]
         seen_boundaries[representation] = free_gap_boundary
-        score = 10.0 if representation == "H:K" else 1.0
+        if representation == "H":
+            score = 100.0
+        else:
+            score = 10.0 if representation == "HK" else 1.0
         return reduced, np.zeros((len(query), len(reference) + 2)), score
 
     corrected_shapes = []
@@ -340,19 +392,50 @@ def test_scfv_mode_selects_and_corrects_a_composite_reference(monkeypatch):
     alignment, selected, score = align(
         np.zeros((2, 64)), frozenset(), "auto", 0.0, scfv=True
     )
-    assert selected == "H:K"
+    assert selected == "HK"
     assert score == 10.0
     assert alignment.shape == (2, 256)
     assert corrected_shapes == [(2, 128), (2, 128)]
     assert seen_boundaries == {
-        "H": -1,
-        "K": -1,
-        "L": -1,
-        "H:K": 1,
-        "H:L": 1,
-        "K:H": 1,
-        "L:H": 1,
+        "HK": (1,),
+        "HL": (1,),
+        "KH": (1,),
+        "LH": (1,),
     }
+
+
+def test_requested_candidates_and_higher_order_boundaries_are_exact(
+    monkeypatch,
+):
+    references = {
+        "H": (np.zeros((1, 64)), (1,)),
+        "K": (np.ones((1, 64)), (1,)),
+        "L": (np.full((1, 64), 2), (1,)),
+    }
+    seen = []
+
+    def fake_align(query, reference, mode, free_gap_boundary=-1):
+        seen.append((int(reference[0, 0]), free_gap_boundary))
+        reduced = np.zeros((len(query), len(reference)))
+        np.fill_diagonal(reduced, 1)
+        return reduced, np.zeros((len(query), len(reference) + 2)), 1.0
+
+    monkeypatch.setattr(
+        "sabr.alignment.load_references",
+        lambda noise, mode, scfv=False: references,
+    )
+    monkeypatch.setattr("sabr.alignment._align_reference", fake_align)
+    monkeypatch.setattr(
+        "sabr.alignment.apply_corrections",
+        lambda alignment, gap_indices: alignment,
+    )
+
+    alignment, selected, _ = align(
+        np.zeros((3, 64)), frozenset(), "HHK,HHL", 0.0
+    )
+    assert selected == "HHK"
+    assert alignment.shape == (3, 3 * constants.IMGT_MAX_POSITION)
+    assert seen == [(0, (1, 2)), (0, (1, 2))]
 
 
 def test_terminal_gap_penalty_uses_normal_affine_gap_costs():
@@ -369,12 +452,12 @@ def test_terminal_gap_penalty_uses_normal_affine_gap_costs():
     )
 
 
-def test_scfv_terminal_penalty_is_used_only_for_candidate_selection(
+def test_multidomain_terminal_penalty_is_used_only_for_candidate_selection(
     monkeypatch,
 ):
     references = {
         "H": (np.zeros((1, 64)), [1]),
-        "H:K": (np.ones((4, 64)), [1, 2, 129, 130]),
+        "HK": (np.ones((4, 64)), [1, 2, 129, 130]),
     }
 
     def fake_align(query, reference, mode, free_gap_boundary=-1):
@@ -397,7 +480,7 @@ def test_scfv_terminal_penalty_is_used_only_for_candidate_selection(
     )
 
     alignment, selected, score = align(
-        np.zeros((1, 64)), frozenset(), "auto", 0.0, scfv=True
+        np.zeros((1, 64)), frozenset(), "H,HK", 0.0
     )
     assert selected == "H"
     assert score == 8.0

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -13,7 +13,7 @@ from sabr.alignment import (
     _alignment_path,
     _concatenate_reference,
     _terminal_gap_penalty,
-    _validate_scfv_alignment,
+    _validate_multidomain_alignment,
     align,
     load_gap_penalties,
     load_references,
@@ -161,7 +161,7 @@ def test_scfv_alignment_allows_an_unassigned_linker_between_domains():
     alignment[1, 1] = 1
     alignment[3, 128] = 1
     alignment[4, 129] = 1
-    _validate_scfv_alignment(alignment, "HK")
+    _validate_multidomain_alignment(alignment, "HK")
 
 
 def test_higher_order_reference_is_an_ordered_concatenation():

--- a/tests/test_numbering.py
+++ b/tests/test_numbering.py
@@ -261,7 +261,7 @@ def test_reference_metadata_rejects_invalid_or_ambiguous_combinations():
             np.eye(2, dtype=int),
             "AC",
             "imgt",
-            "H:K",
+            "HK",
             ref_type="K",
         )
 
@@ -373,12 +373,37 @@ def test_scfv_numbering_offsets_second_domain_and_numbers_linker(monkeypatch):
         lambda *args: pytest.fail("scFv path completed reference states"),
     )
     monkeypatch.setattr(numbering, "_apply_scheme", fake_scheme)
-    assert number_alignment(alignment, "ACDEF", "imgt", "H:K") == [
+    assert number_alignment(alignment, "ACDEF", "imgt", "HK") == [
         (0, 1, "", "A"),
         (1, 2, "", "C"),
         (2, 2, "A", "D"),
         (3, 129, "", "E"),
         (4, 130, "", "F"),
+    ]
+
+
+def test_higher_order_numbering_offsets_every_domain_and_linker(monkeypatch):
+    alignment = np.zeros((8, 384), dtype=int)
+    alignment[0, 0] = 1
+    alignment[1, 1] = 1
+    alignment[3, 128] = 1
+    alignment[4, 129] = 1
+    alignment[6, 256] = 1
+    alignment[7, 257] = 1
+
+    def fake_scheme(states, sequence, scheme, chain_type):
+        return [((1, ""), sequence[0]), ((2, ""), sequence[1])], 0, 1
+
+    monkeypatch.setattr(numbering, "_apply_scheme", fake_scheme)
+    assert number_alignment(alignment, "ACDEFGHI", "imgt", "HHK") == [
+        (0, 1, "", "A"),
+        (1, 2, "", "C"),
+        (2, 2, "A", "D"),
+        (3, 129, "", "E"),
+        (4, 130, "", "F"),
+        (5, 130, "A", "G"),
+        (6, 257, "", "H"),
+        (7, 258, "", "I"),
     ]
 
 

--- a/tests/test_numbering.py
+++ b/tests/test_numbering.py
@@ -350,7 +350,7 @@ def test_number_alignment_retains_original_query_rows(monkeypatch):
     ]
 
 
-def test_scfv_numbering_offsets_second_domain_and_numbers_linker(monkeypatch):
+def test_scfv_numbering_uses_1000_block_and_sequential_linker(monkeypatch):
     alignment = np.zeros((5, 256), dtype=int)
     alignment[0, 0] = 1
     alignment[1, 1] = 1
@@ -376,9 +376,9 @@ def test_scfv_numbering_offsets_second_domain_and_numbers_linker(monkeypatch):
     assert number_alignment(alignment, "ACDEF", "imgt", "HK") == [
         (0, 1, "", "A"),
         (1, 2, "", "C"),
-        (2, 2, "A", "D"),
-        (3, 129, "", "E"),
-        (4, 130, "", "F"),
+        (2, 3, "", "D"),
+        (3, 1001, "", "E"),
+        (4, 1002, "", "F"),
     ]
 
 
@@ -398,12 +398,12 @@ def test_higher_order_numbering_offsets_every_domain_and_linker(monkeypatch):
     assert number_alignment(alignment, "ACDEFGHI", "imgt", "HHK") == [
         (0, 1, "", "A"),
         (1, 2, "", "C"),
-        (2, 2, "A", "D"),
-        (3, 129, "", "E"),
-        (4, 130, "", "F"),
-        (5, 130, "A", "G"),
-        (6, 257, "", "H"),
-        (7, 258, "", "I"),
+        (2, 3, "", "D"),
+        (3, 1001, "", "E"),
+        (4, 1002, "", "F"),
+        (5, 1003, "", "G"),
+        (6, 2001, "", "H"),
+        (7, 2002, "", "I"),
     ]
 
 


### PR DESCRIPTION
## Summary
- accept ordered, comma-separated chain-type candidates such as `H,K`, `HK,HL`, and `HHK,HHL`
- construct and align arbitrary higher-order domain references with free linker gaps at every domain boundary
- number adjacent domains in 1000-wide blocks (`1–128`, `1001–1128`, `2001–2128`, ...)
- number linker residues sequentially after the preceding domain
- make `--scfv` search only `HK,HL,KH,LH`
- update CLI/API documentation and regression coverage

## Verification
- `JAX_PLATFORMS=cpu python -m pytest --cov=sabr --cov-report=term-missing` (183 passed, 96.01% coverage)
- `pre-commit run --all-files`