### PR TITLE
Use kappa references for TCR chains

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,10 +135,10 @@ residues exceeds 2.66 Å. A gap skips only the affected CDR or DE-loop
 correction and emits a warning; other regions continue normally.
 
 T-cell receptors are not an officially supported SAbR target. For
-experimental low-level use, align a TCR against the K reference because that
-reference includes IMGT position 10, as TCRs do. Pass the actual TCR chain
-type (`A`, `B`, `G`, or `D`) only to the ANARCI conversion step, together with
-`ref_type="K"`. This workaround is limited to IMGT and AHo numbering; the
+experimental use, pass the actual TCR chain type (`A`, `B`, `G`, or `D`) with
+`--chain-type` or `chain_type`. SAbR aligns only against the K reference,
+which includes IMGT position 10 as TCRs do, while retaining the TCR type for
+ANARCI conversion. This workflow is limited to IMGT and AHo numbering; the
 other bundled schemes are antibody-specific.
 
 ## Development

--- a/docs/index.md
+++ b/docs/index.md
@@ -163,13 +163,12 @@ Unknown or ambiguous polymer chemistry is rejected rather than converted to
 
 ## Experimental TCR use
 
-T-cell receptors are not an officially supported SAbR target. Experimental
-users of the low-level alignment and numbering modules should align TCRs
-against the K reference because it includes IMGT position 10, as TCRs do.
-Pass the actual TCR chain type (`A`, `B`, `G`, or `D`) only to the ANARCI
-conversion step, together with `ref_type="K"`. This workaround supports IMGT
-and AHo numbering only; Chothia, Kabat, Martin, and Wolfguy are
-antibody-specific.
+T-cell receptors are not an officially supported SAbR target. For
+experimental use, pass the actual TCR chain type (`A`, `B`, `G`, or `D`) as
+`--chain-type` or `chain_type`. SAbR aligns only against the K reference,
+which includes IMGT position 10 as TCRs do, while retaining the TCR type for
+ANARCI conversion. This workflow supports IMGT and AHo numbering only;
+Chothia, Kabat, Martin, and Wolfguy are antibody-specific.
 
 ## Errors
 

--- a/src/sabr/alignment.py
+++ b/src/sabr/alignment.py
@@ -348,6 +348,8 @@ def align(
         candidates = (
             constants.SCFV_CHAIN_TYPES if scfv else constants.CHAIN_TYPES
         )
+    elif chain_type in constants.TCR_CHAIN_TYPES:
+        candidates = ("K",)
     else:
         candidates = tuple(chain_type.split(","))
     best = None

--- a/src/sabr/api.py
+++ b/src/sabr/api.py
@@ -24,9 +24,15 @@ def _normalize_chain_type(
     noise_level: float,
     mode: str,
 ) -> str:
-    """Normalize an automatic or comma-separated domain candidate list."""
-    if chain_type.strip().lower() == "auto":
+    """Normalize a TCR type or antibody domain candidate list."""
+    if not isinstance(chain_type, str):
+        raise ValueError("chain_type must be a supported type or 'auto'.")
+
+    normalized = chain_type.strip().upper()
+    if normalized == "AUTO":
         return "auto"
+    if normalized in constants.TCR_CHAIN_TYPES:
+        return normalized
 
     reference_types = tuple(load_references(noise_level, mode))
     candidates = sorted(
@@ -37,9 +43,11 @@ def _normalize_chain_type(
         for candidate in candidates
     ):
         choices = ", ".join(("auto", *reference_types))
+        tcr_choices = ", ".join(constants.TCR_CHAIN_TYPES)
         raise ValueError(
-            "chain_type must be 'auto' or comma-separated representations "
-            f"built from {choices}."
+            "chain_type must be a TCR type or comma-separated antibody "
+            f"representations built from {choices}; TCR types are "
+            f"{tcr_choices}."
         )
     return ",".join(candidates)
 
@@ -133,8 +141,9 @@ def renumber_structure(
 
     ``mode="softalign"`` selects the SoftAlign encoder, references, and gap
     penalties as one scientifically consistent parameter set. ``chain_type``
-    accepts a comma-separated set of domain representations such
-    as ``"H,K,HK,HL"``. ``scfv=True`` is equivalent to
+    accepts a comma-separated set of antibody domain representations such
+    as ``"H,K,HK,HL"``, or one TCR type from ``"A,B,G,D"``. TCR types align
+    only against the K reference. ``scfv=True`` is equivalent to
     ``chain_type="HK,HL,KH,LH"``.
     """
     options = _RenumberOptions(
@@ -160,10 +169,15 @@ def renumber_structure(
         selected_type,
         score,
     )
+    numbering_type = (
+        options.chain_type
+        if options.chain_type in constants.TCR_CHAIN_TYPES
+        else selected_type
+    )
     numbered = number_alignment(
         imgt_alignment,
         data.sequence,
         options.scheme,
-        selected_type,
+        numbering_type,
     )
     return apply_numbering(structure, chain, data, numbered)

--- a/src/sabr/cli.py
+++ b/src/sabr/cli.py
@@ -115,8 +115,8 @@ def _write_structure(structure, path: Path) -> None:
     show_default=True,
     metavar="TYPES",
     help=(
-        "Comma-separated reference domain representations, such as H,K or "
-        "HK,HL."
+        "Comma-separated antibody domain representations, such as H,K or "
+        "HK,HL; TCR types A, B, G, and D use the K reference."
     ),
 )
 @click.option(

--- a/src/sabr/constants.py
+++ b/src/sabr/constants.py
@@ -31,6 +31,7 @@ SW_GAP_OPEN = -2.525591
 # SoftAlign params
 DEFAULT_TEMPERATURE = 1e-4
 CHAIN_TYPES = ("H", "K", "L")
+TCR_CHAIN_TYPES = ("A", "B", "G", "D")
 SCFV_CHAIN_TYPES = ("HK", "HL", "KH", "LH")
 NOISE_LEVELS = (0.0, 0.2, 0.5, 1.0, 2.0)
 MODES = ("sabr", "softalign")

--- a/src/sabr/numbering.py
+++ b/src/sabr/numbering.py
@@ -48,11 +48,10 @@ def _load_missing_imgt_positions() -> dict[str, frozenset[int]]:
 
 
 # These are ANARCI's T-cell receptor chain labels. The public SAbR pipeline
-# supports antibody references H/K/L; A/B/G/D are accepted only by the
-# low-level numbering conversion for the experimental TCR workflow documented
-# in the README. Of the vendored ANARCI schemes, only IMGT and AHo define TCR
-# behavior (and AHo needs the actual TCR chain label).
-_TCR_CHAIN_TYPES = frozenset({"A", "B", "G", "D"})
+# aligns them against K but retains the actual label for numbering. Of the
+# vendored ANARCI schemes, only IMGT and AHo define TCR behavior (and AHo needs
+# the actual TCR chain label).
+_TCR_CHAIN_TYPES = frozenset(constants.TCR_CHAIN_TYPES)
 
 
 def _validate_reference_positions(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,7 +7,7 @@ from Bio.PDB import Atom, Chain, PDBParser, Residue
 from Bio.PDB.Structure import Structure
 
 import sabr.api as api
-from sabr import renumber_structure
+from sabr import constants, renumber_structure
 from sabr.structure import extract_chain
 
 DATA = Path(__file__).parent / "data"
@@ -227,6 +227,42 @@ def test_chain_type_domain_choices_come_from_reference_asset(monkeypatch):
             mode="sabr",
             scfv=False,
         )
+
+
+@pytest.mark.parametrize("chain_type", constants.TCR_CHAIN_TYPES)
+def test_tcr_chain_uses_k_reference_and_actual_numbering_type(
+    monkeypatch, chain_type
+):
+    structure = PDBParser(QUIET=True).get_structure(
+        "heavy", DATA / "test_heavy_chain.pdb"
+    )
+    captured = {}
+    monkeypatch.setattr(
+        api,
+        "encode",
+        lambda coords, mode: np.zeros((len(coords), 64)),
+    )
+
+    def fake_align(embeddings, gaps, requested_type, noise, mode, scfv):
+        captured["alignment_type"] = requested_type
+        return np.zeros((len(embeddings), 128), dtype=int), "K", 0.0
+
+    def fake_number(alignment, sequence, scheme, numbering_type):
+        captured["numbering_type"] = numbering_type
+        return [
+            (index, index + 1, "", amino_acid)
+            for index, amino_acid in enumerate(sequence)
+        ]
+
+    monkeypatch.setattr(api, "align", fake_align)
+    monkeypatch.setattr(api, "number_alignment", fake_number)
+
+    renumber_structure(structure, "F", chain_type=chain_type.lower())
+
+    assert captured == {
+        "alignment_type": chain_type,
+        "numbering_type": chain_type,
+    }
 
 
 def test_missing_backbone_is_reported_with_the_residue():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -124,6 +124,29 @@ def test_cli_accepts_every_reference_noise_level(
     assert captured["noise_level"] == float(noise_level)
 
 
+@pytest.mark.parametrize("chain_type", ("A", "B", "G", "D"))
+def test_cli_accepts_tcr_chain_types(monkeypatch, tmp_path, chain_type):
+    captured = {}
+    monkeypatch.setattr(cli, "renumber_structure", _passthrough(captured))
+    output = tmp_path / f"tcr-{chain_type}.pdb"
+    result = CliRunner().invoke(
+        cli.main,
+        [
+            "-i",
+            str(DATA / "test_heavy_chain.pdb"),
+            "-c",
+            "F",
+            "-o",
+            str(output),
+            "--chain-type",
+            chain_type,
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["chain_type"] == chain_type
+
+
 def test_cli_forwards_scfv_mode(monkeypatch, tmp_path):
     captured = {}
     monkeypatch.setattr(cli, "renumber_structure", _passthrough(captured))

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -352,6 +352,34 @@ def test_explicit_chain_type_aligns_only_its_reference(monkeypatch, chain_type):
     assert seen == [constants.CHAIN_TYPES.index(chain_type)]
 
 
+@pytest.mark.parametrize("chain_type", constants.TCR_CHAIN_TYPES)
+def test_tcr_chain_type_aligns_only_kappa_reference(monkeypatch, chain_type):
+    references = {
+        candidate: (np.full((1, 64), index), [1])
+        for index, candidate in enumerate(constants.CHAIN_TYPES)
+    }
+    seen = []
+
+    def fake_align(query, reference, mode):
+        seen.append(int(reference[0, 0]))
+        return np.ones((len(query), 1)), np.zeros((len(query), 3)), 1.0
+
+    monkeypatch.setattr(
+        "sabr.alignment.load_references",
+        lambda noise, mode, scfv=False: references,
+    )
+    monkeypatch.setattr("sabr.alignment._align_reference", fake_align)
+    monkeypatch.setattr(
+        "sabr.alignment.apply_corrections",
+        lambda alignment, gap_indices: alignment,
+    )
+
+    _, selected, _ = align(np.zeros((1, 64)), frozenset(), chain_type, 0.0)
+
+    assert selected == "K"
+    assert seen == [constants.CHAIN_TYPES.index("K")]
+
+
 def test_scfv_mode_selects_and_corrects_a_composite_reference(monkeypatch):
     representations = (
         *constants.CHAIN_TYPES,


### PR DESCRIPTION
## Summary

- accept A, B, G, and D as TCR chain types in the API and CLI
- align TCR chains only against the kappa reference while preserving the requested type for numbering
- document the experimental TCR workflow and add API, alignment, and CLI regression coverage

## Testing

- pytest -q: 182 passed, 1 existing warning
- black, isort, and flake8 pre-commit hooks passed