### PR TITLE
Block renumbering across structural gaps by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ sabr -i INPUT -c CHAIN -o OUTPUT
      [-m sabr|softalign]
      [--residue-range START END]
      [--scfv]
+     [--dangerously-allow-structural-gaps]
      [--no-mmcif]
      [--overwrite] [-v]
 ```
@@ -126,8 +127,12 @@ For unusually long loops that need extended insertion codes, use mmCIF output.
   compared; the underlying alignments and raw alignment scores are unchanged.
 
 A structural gap is detected when the C–N distance between consecutive
-residues exceeds 2.66 Å. A gap skips only the affected CDR or DE-loop
-correction and emits a warning; other regions continue normally.
+residues exceeds 2.66 Å. SAbR refuses to run when a structural gap is
+detected. To override this safety check, pass
+`--dangerously-allow-structural-gaps`; a warning is printed before any other
+runtime output. Python API callers can set
+`dangerously_allow_structural_gaps=True`. When overridden, a gap skips only
+the affected CDR or DE-loop correction and other regions continue normally.
 
 T-cell receptors are not an officially supported SAbR target. For
 experimental low-level use, align a TCR against the K reference because that

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,6 +55,7 @@ sabr -i INPUT -c CHAIN -o OUTPUT
      [-m sabr|softalign]
      [--residue-range START END]
      [--scfv]
+     [--dangerously-allow-structural-gaps]
      [--no-mmcif]
      [--overwrite] [-v]
 ```
@@ -112,6 +113,7 @@ renumber_structure(
     residue_range: tuple[int, int] | None = None,
     mode: str = "sabr",
     scfv: bool = False,
+    dangerously_allow_structural_gaps: bool = False,
 )
 ```
 
@@ -139,9 +141,13 @@ non-atomic mmCIF category.
 
 ## Structural gaps and modified residues
 
-A C–N distance above 2.66 Å is treated as a structural gap. If a gap crosses a
-CDR or the DE loop between IMGT anchors 79 and 85, SAbR warns and retains the
-learned alignment for that region while continuing corrections elsewhere.
+A C–N distance above 2.66 Å is treated as a structural gap. SAbR refuses to
+run if the selected chain contains one. CLI users can explicitly override the
+safety check with `--dangerously-allow-structural-gaps`, which prints a warning
+before any other runtime output. Python API users can set
+`dangerously_allow_structural_gaps=True`. With the override enabled, a gap
+crossing a CDR or the DE loop between IMGT anchors 79 and 85 retains the
+learned alignment for that region while corrections elsewhere continue.
 Otherwise, DE-loop residues fill 80 first, then 84 back through 81; additional
 residues are inserted after 82.
 

--- a/src/sabr/api.py
+++ b/src/sabr/api.py
@@ -92,6 +92,7 @@ class _RenumberOptions:
     residue_range: tuple[int, int] | None
     mode: str
     scfv: bool
+    dangerously_allow_structural_gaps: bool = False
 
     def __post_init__(self) -> None:
         self.scheme = _normalize_choice(
@@ -109,6 +110,10 @@ class _RenumberOptions:
             raise ValueError("scfv must be a boolean.")
         if self.scfv and self.chain_type != "auto":
             raise ValueError("scfv requires chain_type='auto'.")
+        if not isinstance(self.dangerously_allow_structural_gaps, bool):
+            raise ValueError(
+                "dangerously_allow_structural_gaps must be a boolean."
+            )
 
 
 def renumber_structure(
@@ -120,12 +125,15 @@ def renumber_structure(
     residue_range: tuple[int, int] | None = None,
     mode: str = "sabr",
     scfv: bool = False,
+    dangerously_allow_structural_gaps: bool = False,
 ):
     """Return a renumbered copy of a Biopython structure.
 
     ``mode="softalign"`` selects the SoftAlign encoder, references, and gap
     penalties as one scientifically consistent parameter set. ``scfv=True``
-    adds the four supported two-domain composite references.
+    adds the four supported two-domain composite references. Structural gaps
+    are rejected before model execution unless
+    ``dangerously_allow_structural_gaps=True`` is explicitly supplied.
     """
     options = _RenumberOptions(
         scheme=scheme,
@@ -134,8 +142,18 @@ def renumber_structure(
         residue_range=residue_range,
         mode=mode,
         scfv=scfv,
+        dangerously_allow_structural_gaps=dangerously_allow_structural_gaps,
     )
     data = extract_chain(structure, chain, options.residue_range)
+    if data.gap_indices and not options.dangerously_allow_structural_gaps:
+        count = len(data.gap_indices)
+        noun = "gap was" if count == 1 else "gaps were"
+        raise ValueError(
+            f"{count} structural {noun} detected in the selected chain. "
+            "SAbR will not run unless structural gaps are explicitly allowed. "
+            "Pass --dangerously-allow-structural-gaps on the command line or "
+            "set dangerously_allow_structural_gaps=True in the Python API."
+        )
     embeddings = encode(data.coords, options.mode)
     imgt_alignment, selected_type, score = align(
         embeddings,

--- a/src/sabr/cli.py
+++ b/src/sabr/cli.py
@@ -139,6 +139,11 @@ def _write_structure(structure, path: Path) -> None:
     help="Also try H:K, H:L, K:H, and L:H composite references.",
 )
 @click.option(
+    "--dangerously-allow-structural-gaps",
+    is_flag=True,
+    help="Run despite structural gaps; results may be invalid.",
+)
+@click.option(
     "--no-mmcif",
     is_flag=True,
     help="Forbid automatic mmCIF output for extended insertion codes.",
@@ -155,6 +160,7 @@ def main(
     mode: str,
     residue_range: tuple | None,
     scfv: bool,
+    dangerously_allow_structural_gaps: bool,
     no_mmcif: bool,
     overwrite: bool,
     verbose: bool,
@@ -165,6 +171,11 @@ def main(
         format="%(levelname)s: %(message)s",
         force=True,
     )
+    if dangerously_allow_structural_gaps:
+        LOGGER.warning(
+            "Structural-gap safety check disabled by "
+            "--dangerously-allow-structural-gaps; results may be invalid."
+        )
     temporary = None
     try:
         structure = _read_structure(input_path)
@@ -183,6 +194,9 @@ def main(
             mode=mode,
             residue_range=residue_range,
             scfv=scfv,
+            dangerously_allow_structural_gaps=(
+                dangerously_allow_structural_gaps
+            ),
         )
         resolved_output_path = _resolve_output_path(
             result, output_path, no_mmcif=no_mmcif

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -166,6 +166,35 @@ def test_softalign_mode_is_forwarded_to_encoder_and_alignment(monkeypatch):
     }
 
 
+def test_structural_gap_stops_before_model_execution(monkeypatch):
+    structure = PDBParser(QUIET=True).get_structure("gap", DATA / "8sve_L.pdb")
+
+    def unexpected_encode(coords, mode):
+        pytest.fail("encoder ran despite a structural gap")
+
+    monkeypatch.setattr(api, "encode", unexpected_encode)
+    with pytest.raises(
+        ValueError,
+        match="SAbR will not run.*--dangerously-allow-structural-gaps",
+    ):
+        renumber_structure(structure, "M")
+
+
+def test_structural_gap_can_be_explicitly_allowed(monkeypatch):
+    captured_modes = {}
+    _stub_pipeline(monkeypatch, captured_modes)
+    structure = PDBParser(QUIET=True).get_structure("gap", DATA / "8sve_L.pdb")
+
+    result = renumber_structure(
+        structure,
+        "M",
+        dangerously_allow_structural_gaps=True,
+    )
+
+    assert isinstance(result, Structure)
+    assert captured_modes == {"encoder": "sabr", "alignment": "sabr"}
+
+
 def test_chain_type_choices_come_from_reference_asset(monkeypatch):
     monkeypatch.setattr(
         api,
@@ -250,6 +279,10 @@ def test_multiple_models_are_rejected():
         ({"residue_range": (False, 10)}, "residue_range"),
         ({"scfv": "yes"}, "scfv"),
         ({"scfv": True, "chain_type": "H"}, "auto"),
+        (
+            {"dangerously_allow_structural_gaps": "yes"},
+            "dangerously_allow_structural_gaps",
+        ),
     ],
 )
 def test_invalid_public_options_fail_before_model_execution(kwargs, message):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -58,6 +58,7 @@ def test_cli_maps_the_complete_compact_interface(monkeypatch, tmp_path):
             "2",
             "127",
             "--overwrite",
+            "--dangerously-allow-structural-gaps",
             "-v",
         ],
     )
@@ -71,7 +72,12 @@ def test_cli_maps_the_complete_compact_interface(monkeypatch, tmp_path):
         "mode": "softalign",
         "residue_range": (2, 127),
         "scfv": False,
+        "dangerously_allow_structural_gaps": True,
     }
+    assert result.output.startswith(
+        "WARNING: Structural-gap safety check disabled by "
+        "--dangerously-allow-structural-gaps"
+    )
     assert "pipeline details" in result.output
 
 
@@ -97,6 +103,7 @@ def test_cli_defaults_are_deterministic_and_quiet(monkeypatch, tmp_path):
     assert captured["mode"] == "sabr"
     assert captured["residue_range"] is None
     assert captured["scfv"] is False
+    assert captured["dangerously_allow_structural_gaps"] is False
     assert "pipeline details" not in result.output
 
 
@@ -300,6 +307,25 @@ def test_real_softalign_cli_round_trip(tmp_path):
     assert list(parsed[0]["F"])[-1].id[1] == 128
 
 
+def test_cli_rejects_structural_gap_without_override(tmp_path):
+    output = tmp_path / "8sve-numbered.cif"
+    result = CliRunner().invoke(
+        cli.main,
+        [
+            "-i",
+            str(DATA / "8sve_L.pdb"),
+            "-c",
+            "M",
+            "-o",
+            str(output),
+        ],
+    )
+    assert result.exit_code != 0
+    assert "SAbR will not run" in result.output
+    assert "--dangerously-allow-structural-gaps" in result.output
+    assert not output.exists()
+
+
 def test_8sve_cli_mmcif_round_trip_matches_full_golden(tmp_path):
     golden = json.loads((DATA / "8sve_cdr1_imgt.json").read_text())
     output = tmp_path / "8sve-numbered.cif"
@@ -314,9 +340,14 @@ def test_8sve_cli_mmcif_round_trip_matches_full_golden(tmp_path):
             str(output),
             "-t",
             "K",
+            "--dangerously-allow-structural-gaps",
         ],
     )
     assert result.exit_code == 0, result.output
+    assert result.output.startswith(
+        "WARNING: Structural-gap safety check disabled by "
+        "--dangerously-allow-structural-gaps"
+    )
     parsed = MMCIFParser(QUIET=True).get_structure("output", output)
     actual = [
         [residue.id[1], residue.id[2].strip()]
@@ -509,4 +540,5 @@ def test_help_and_version_are_available():
     assert "--scfv" in help_result.output
     assert "--mode" in help_result.output
     assert "--no-mmcif" in help_result.output
+    assert "--dangerously-allow-structural-gaps" in help_result.output
     assert version_result.exit_code == 0

--- a/tests/test_numbering.py
+++ b/tests/test_numbering.py
@@ -298,6 +298,7 @@ def test_8sve_huge_cdr1_matches_the_accepted_full_mapping():
             "M",
             scheme="imgt",
             chain_type="K",
+            dangerously_allow_structural_gaps=True,
         )
     assert [str(item.message) for item in warnings] == golden["warning"]
     target_residues = [


### PR DESCRIPTION
## Summary

- stop renumbering before encoder/model execution when the selected chain has a structural gap
- add the explicit --dangerously-allow-structural-gaps CLI and Python API override
- print the override warning before all other runtime output
- document the safety behavior and cover blocked and allowed paths

## Verification

- JAX_PLATFORMS=cpu pytest --cov=sabr -q (174 passed, 96.47% coverage)
- pre-commit run --all-files