### PR TITLE
Clarify encoder provenance and structural-gap behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
 # SAbR
 
 SAbR (Structure-based Antibody Renumbering) assigns antibody residue numbers
-from backbone coordinates. It combines the original trained Haiku encoder with
-the original affine Smith–Waterman alignment and ANARCI numbering rules.
-
-SAbR is intentionally small and feature-complete. It provides one Python API
-and one command-line program.
+from backbone coordinates. It combines a fine-tuned version of the ProteinMPNN
+encoder from [SoftAlign](https://github.com/jtrinquier/SoftAlign) with the
+original affine Smith–Waterman alignment and ANARCI numbering rules.
 
 The complete usage guide is available in the
 [SAbR documentation](https://sabr.readthedocs.io/).
@@ -132,7 +130,8 @@ For unusually long loops that need extended insertion codes, use mmCIF output.
 
 A structural gap is detected when the C–N distance between consecutive
 residues exceeds 2.66 Å. A gap skips only the affected CDR or DE-loop
-correction and emits a warning; other regions continue normally.
+correction and emits a warning; other regions continue normally. Performance
+degrades when structural gaps are included in the input.
 
 T-cell receptors are not an officially supported SAbR target. For
 experimental use, pass the actual TCR chain type (`A`, `B`, `G`, or `D`) with

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,9 @@
 
 SAbR assigns antibody residue numbers from backbone coordinates. It accepts
 PDB and mmCIF structures, preserves the input object, and supports IMGT,
-Chothia, Kabat, Martin, AHo, and Wolfguy numbering.
+Chothia, Kabat, Martin, AHo, and Wolfguy numbering. Its encoder is a fine-tuned
+version of the ProteinMPNN encoder from
+[SoftAlign](https://github.com/jtrinquier/SoftAlign).
 
 ## Installation
 
@@ -159,8 +161,9 @@ before any other runtime output. Python API users can set
 `dangerously_allow_structural_gaps=True`. With the override enabled, a gap
 crossing a CDR or the DE loop between IMGT anchors 79 and 85 retains the
 learned alignment for that region while corrections elsewhere continue.
-Otherwise, DE-loop residues fill 80 first, then 84 back through 81; additional
-residues are inserted after 82.
+Even with the override, performance degrades when structural gaps are
+included. Without a gap crossing that region, DE-loop residues fill 80 first,
+then 84 back through 81; additional residues are inserted after 82.
 
 Supported modified peptide residues are translated to their canonical parent
 only for sequence generation. Original residue names and atoms are preserved.


### PR DESCRIPTION
## Summary
- describe the SAbR encoder as a fine-tuned ProteinMPNN encoder from SoftAlign
- link to the SoftAlign repository
- remove the small and feature-complete description
- document degraded performance when structural gaps are present

## Testing
- documentation-only change
- git diff --check