### PR TITLE
Remove obsolete README details

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,17 +163,6 @@ the fixed asset hashes, encoder and alignment baselines, all numbering schemes,
 H/K/L selection, regional corrections, structure-object behavior, and CLI
 failure handling.
 
-## Deferred full benchmark
-
-The historical pre-2021 SAbDab manifest contains approximately 1,012 chains.
-The current method scores about 90% on that set, not 100%. The full corpus is
-not bundled or downloaded by CI.
-
-Future benchmark work should create a checksum-pinned corpus, verify residue
-IDs, insertion codes, and coordinate parity, and compare a lossless archive
-with Foldcomp before adding a separate manual or nightly workflow. This is a
-benchmarking TODO, not a unit-test or release requirement.
-
 ## License and attribution
 
 SAbR is distributed under the repository license. The vendored ANARCI

--- a/README.md
+++ b/README.md
@@ -87,22 +87,6 @@ rejects multi-model structures rather than silently modifying only one model.
 If a partial range would create duplicate residue IDs with unchanged residues,
 the operation fails with an explanation.
 
-The copy preserves metadata represented by the input Biopython object.
-Alternate conformers are normalized deterministically: a complete blank-altloc
-backbone is preferred, then the complete conformer with the greatest summed
-occupancy, with altloc name as the final tie-breaker. Selections above 1,024
-polymer residues are rejected before quadratic model work; use
-`residue_range` to select the antibody domain.
-
-Modified peptide residues are translated only for sequence generation. Their
-original names and atoms remain unchanged. The committed mapping was generated
-from the wwPDB Chemical Component Dictionary snapshot dated 2026-07-11
-(`components.cif.gz` SHA-256
-`0b3323123ec10b997afe1c530b4cad30306e60b451b2b062c59bc9bb5cbe0679`) and
-contains only peptide-linking components with exactly one canonical amino-acid
-parent. Unsupported or ambiguous polymer chemistry fails explicitly; no
-runtime network access occurs.
-
 For unusually long loops that need extended insertion codes, use mmCIF output.
 
 ## Scientific behavior

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SAbR
+# Structure-based Antibody Renumbering
 
 SAbR (Structure-based Antibody Renumbering) assigns antibody residue numbers
 from backbone coordinates. It combines the original trained Haiku encoder with

--- a/README.md
+++ b/README.md
@@ -100,7 +100,6 @@ For unusually long loops that need extended insertion codes, use mmCIF output.
 - Deterministic CDR gap distribution and DE-loop correction are always
   applied. Between IMGT anchors 79 and 85, DE-loop residues fill 80 first,
   then 84 back through 81; additional residues are inserted after 82.
-- No deterministic C-terminal correction is applied.
 - Automatic chain selection aligns against H, K, and L references and uses
   the highest score, with deterministic H/K/L tie order.
 - `chain_type` candidate order is deterministic and resolves score ties.

--- a/README.md
+++ b/README.md
@@ -97,9 +97,6 @@ For unusually long loops that need extended insertion codes, use mmCIF output.
   `softalign_embeddings.npz`, and the exact penalties in
   `softalign_gap.npz` as one parameter set.
 - Alignment uses the original differentiable affine Smith–Waterman method.
-- In `sabr` mode, gap extension is `-0.175027` and gap opening is `-2.525591`.
-  In `softalign` mode, they are `0.1942468136548996` and
-  `-2.5441808700561523`, respectively, as stored in the repository asset.
 - Deterministic CDR gap distribution and DE-loop correction are always
   applied. Between IMGT anchors 79 and 85, DE-loop residues fill 80 first,
   then 84 back through 81; additional residues are inserted after 82.


### PR DESCRIPTION
## Summary
- remove the deferred full benchmark section
- remove detailed alternate-conformer, input-size, and modified-residue implementation notes
- leave the active test, publishing, and Docker workflows unchanged

The historical benchmark workflows and supporting scripts are already absent from the current repository.

## Checks
- `git diff --check`
- repository-wide search confirms no benchmark, SAbDab, or Foldcomp references remain
- tests not run because these are documentation-only changes and pytest is not installed in the current environment