### PR TITLE
Document Docker usage in README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,23 @@ on CPU using NumPy and SciPy
 pip install sabr-kit
 ```
 
+### Docker
+
+With Docker installed and running, pull the image and run SAbR from the
+directory containing `antibody.pdb`:
+
+```bash
+docker pull ghcr.io/delalamo/sabr:latest
+docker run --rm -v "$PWD:/workspace" ghcr.io/delalamo/sabr:latest \
+  -i antibody.pdb -c H -o numbered.pdb
+```
+
+The mounted directory makes the input available inside the container and
+saves `numbered.pdb` back to the same directory on your computer. The image
+runs `sabr` directly; append any of the command-line options below, or use
+`docker run --rm ghcr.io/delalamo/sabr:latest --help` for help. To pin a
+release, replace `latest` with its version tag (without the leading `v`).
+
 ## Command line
 
 ```bash

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,23 @@ on CPU using NumPy and SciPy.
 pip install sabr-kit
 ```
 
+### Docker
+
+With Docker installed and running, pull the image and run SAbR from the
+directory containing `antibody.pdb`:
+
+```bash
+docker pull ghcr.io/delalamo/sabr:latest
+docker run --rm -v "$PWD:/workspace" ghcr.io/delalamo/sabr:latest \
+  -i antibody.pdb -c H -o numbered.pdb
+```
+
+The mounted directory makes the input available inside the container and
+saves `numbered.pdb` back to the same directory on your computer. The image
+runs `sabr` directly; append any of the command-line options below, or use
+`docker run --rm ghcr.io/delalamo/sabr:latest --help` for help. To pin a
+release, replace `latest` with its version tag (without the leading `v`).
+
 ## Command line
 
 Renumber chain `H` using the default IMGT scheme and automatic heavy,


### PR DESCRIPTION
The published Docker image had no usage instructions in the README or documentation. Add a short Docker section to both with commands to pull the image and renumber an antibody structure, explaining the mounted input/output directory, CLI help, and release version tags.

Validation: checked the commands against the Dockerfile and release workflow on main; `git diff --check` passes. The example was not executed because Docker is not installed locally.
