### PR TITLE
Fix Docker badge to track latest tag push

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Python checks](https://github.com/delalamo/SAbR/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/delalamo/SAbR/actions/workflows/test.yml)
 [![Documentation](https://readthedocs.org/projects/sabr/badge/?version=latest)](https://sabr.readthedocs.io/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
-[![Docker build](https://github.com/delalamo/SAbR/actions/workflows/docker-build.yml/badge.svg)](https://github.com/delalamo/SAbR/actions/workflows/docker-build.yml)
+[![Docker build](https://github.com/delalamo/SAbR/actions/workflows/docker-build.yml/badge.svg?event=push)](https://github.com/delalamo/SAbR/actions/workflows/docker-build.yml?query=event%3Apush)
 [![PyPI downloads](https://img.shields.io/pypi/dm/sabr-kit)](https://pypi.org/project/sabr-kit/)
 
 SAbR (Structure-based Antibody Renumbering) assigns antibody residue numbers


### PR DESCRIPTION
The Docker badge was showing an older failed run on `main` even though newer tagged images had published successfully. Filter the badge and its workflow link to push events; this workflow only accepts `v*` tag pushes, so the badge follows the most recently pushed version tag without a hardcoded version.

Validation: confirmed the live filtered badge reports passing for the successful v0.5.0 tag build, checked the workflow's tag-only push trigger, and ran `git diff --check`.
